### PR TITLE
Feature hardware interface

### DIFF
--- a/firmware/motion_board/README.md
+++ b/firmware/motion_board/README.md
@@ -19,7 +19,9 @@ For example, to set KP gain of left wheel regulator, user would send CMD_SET_KP_
 
 If command requires a response for the board, for example CMD_GET_KP_LEFT, board will respond with ID equal to CAN_BASE_ID+1, command byte and the required data.
 
-Special case is CMD_READ_ENCODERS. Board will respond with ID equal to CAN_BASE_ID+2 and 2x4 bytes of data which represent 2 int32_t encoder values. Left encoder value is sent first.
+Special case is CMD_READ_ENCODERS. Board will respond with ID equal to CAN_ENCODER_ID and 2x4 bytes of data which represent 2 int32_t encoder values. Left encoder value is sent first.
+
+If board receives CMD_ENABLE_ENCODER_REPORT it will send encoder data at fixed frequency (50 Hz) without need for a request (CMD_READ_ENCODERS).
 
 Setting the reference wheel velocities is done through command CMD_SET_SETPOINTS by sending 2 int16_t values for left and the right wheel.
 
@@ -44,6 +46,8 @@ Setting the reference wheel velocities is done through command CMD_SET_SETPOINTS
 | Turn off motors | `CAN_BASE_ID` | `CMD_MOTOR_OFF` | | |
 | Turn on motors | `CAN_BASE_ID` | `CMD_MOTOR_ON` | | |
 | Reset left and right pid regulators | `CAN_BASE_ID` | `CMD_RESET_REGULATORS` | | |
+| Enable encoder value reporting at fixed frequency (50 Hz) | `CAN_BASE_ID` | `CMD_ENABLE_ENCODER_REPORT` | | |
+| Disable encoder value reporting at fixed frequency (50 Hz) | `CAN_BASE_ID` | `CMD_DISABLE_ENCODER_REPORT` | | |
 
 
 

--- a/firmware/motion_board/firmware/pic-motor-controller.X/nbproject/configurations.xml
+++ b/firmware/motion_board/firmware/pic-motor-controller.X/nbproject/configurations.xml
@@ -37,6 +37,7 @@
               <itemPath>../src/config/default/peripheral/tmr/plib_tmr_common.h</itemPath>
               <itemPath>../src/config/default/peripheral/tmr/plib_tmr2.h</itemPath>
               <itemPath>../src/config/default/peripheral/tmr/plib_tmr3.h</itemPath>
+              <itemPath>../src/config/default/peripheral/tmr/plib_tmr4.h</itemPath>
             </logicalFolder>
             <logicalFolder name="f2" displayName="uart" projectFiles="true">
               <itemPath>../src/config/default/peripheral/uart/plib_uart_common.h</itemPath>
@@ -95,6 +96,7 @@
             <logicalFolder name="f8" displayName="tmr" projectFiles="true">
               <itemPath>../src/config/default/peripheral/tmr/plib_tmr2.c</itemPath>
               <itemPath>../src/config/default/peripheral/tmr/plib_tmr3.c</itemPath>
+              <itemPath>../src/config/default/peripheral/tmr/plib_tmr4.c</itemPath>
             </logicalFolder>
             <logicalFolder name="f2" displayName="uart" projectFiles="true">
               <itemPath>../src/config/default/peripheral/uart/plib_uart3.c</itemPath>
@@ -131,6 +133,7 @@
         <itemPath>../src/config/default/default.mhc/settings.yml</itemPath>
         <itemPath>../src/config/default/default.mhc/tmr2.yml</itemPath>
         <itemPath>../src/config/default/default.mhc/tmr3.yml</itemPath>
+        <itemPath>../src/config/default/default.mhc/tmr4.yml</itemPath>
         <itemPath>../src/config/default/default.mhc/uart3.yml</itemPath>
       </logicalFolder>
       <itemPath>Makefile</itemPath>

--- a/firmware/motion_board/firmware/src/config/default/default.mhc/can4.yml
+++ b/firmware/motion_board/firmware/src/config/default/default.mhc/can4.yml
@@ -66,6 +66,13 @@ children:
       children:
       - type: User
         attributes: {value: '0'}
+  - type: KeyValueSet
+    attributes: {id: CAN_CFG_SAM}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '0'}
   - type: Integer
     attributes: {id: CAN_CORE_CLOCK_FREQ}
     children:
@@ -73,6 +80,25 @@ children:
       children:
       - type: Dynamic
         attributes: {id: can4, value: '120000000'}
+  - type: Comment
+    attributes: {id: CAN_CORE_CLOCK_INVALID_COMMENT}
+    children:
+    - type: Attributes
+      children:
+      - type: String
+        attributes: {id: text}
+        children:
+        - {type: Value, value: Warning!!! CAN4 Clock Frequency is too high for required
+            Nominal Bit Timing}
+  - type: Comment
+    attributes: {id: CAN_ERRORRATE_COMMENT}
+    children:
+    - type: Attributes
+      children:
+      - type: String
+        attributes: {id: text}
+        children:
+        - {type: Value, value: Warning!!! Error 5.263%}
   - type: Boolean
     attributes: {id: CAN_INTERRUPT_MODE}
     children:
@@ -80,6 +106,23 @@ children:
       children:
       - type: User
         attributes: {value: 'false'}
+  - type: Comment
+    attributes: {id: CAN_TIME_QUANTA_INVALID_COMMENT}
+    children:
+    - type: Attributes
+      children:
+      - type: String
+        attributes: {id: text}
+        children:
+        - {type: Value, value: Warning!!! Number of Time Quanta is too high for required
+            Nominal Bit Timing}
+  - type: Integer
+    attributes: {id: NOMINAL_BITRATE}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '500'}
   - type: Float
     attributes: {id: NOMINAL_SAMPLE_POINT}
     children:

--- a/firmware/motion_board/firmware/src/config/default/default.mhc/core.yml
+++ b/firmware/motion_board/firmware/src/config/default/default.mhc/core.yml
@@ -739,6 +739,20 @@ children:
       children:
       - type: Dynamic
         attributes: {id: core, value: TIMER_3_InterruptHandler}
+  - type: Combo
+    attributes: {id: EVIC_14_PRIORITY}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '2'}
+  - type: Hex
+    attributes: {id: EVIC_14_PRIVALUE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: '524288'}
   - type: Boolean
     attributes: {id: EVIC_188_ENABLE}
     children:
@@ -760,6 +774,41 @@ children:
       children:
       - type: Dynamic
         attributes: {id: core, value: CAN4_Handler}
+  - type: Boolean
+    attributes: {id: EVIC_19_ENABLE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: 'true'}
+  - type: Boolean
+    attributes: {id: EVIC_19_HANDLER_LOCK}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: 'true'}
+  - type: String
+    attributes: {id: EVIC_19_INTERRUPT_HANDLER}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: TIMER_4_InterruptHandler}
+  - type: Combo
+    attributes: {id: EVIC_19_PRIORITY}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '3'}
+  - type: Hex
+    attributes: {id: EVIC_19_PRIVALUE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: '201326592'}
   - type: Boolean
     attributes: {id: EVIC_1_ENABLE}
     children:
@@ -963,6 +1012,20 @@ children:
       children:
       - type: Dynamic
         attributes: {id: core, value: TIMER_2_InterruptHandler}
+  - type: Combo
+    attributes: {id: EVIC_9_PRIORITY}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '4'}
+  - type: Hex
+    attributes: {id: EVIC_9_PRIVALUE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: '4096'}
   - type: Combo
     attributes: {id: EVIC_PRIORITY_1ATTRIBUTE}
     children:
@@ -1417,7 +1480,7 @@ children:
     - type: Values
       children:
       - type: Dynamic
-        attributes: {id: core, value: '268370425'}
+        attributes: {id: core, value: '268370417'}
   - type: Hex
     attributes: {id: PMD5_REG_VALUE}
     children:
@@ -1952,6 +2015,34 @@ children:
       - type: Dynamic
         attributes: {id: tmr3, value: 'true'}
   - type: Boolean
+    attributes: {id: TIMER_4_INTERRUPT_ENABLE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: 'true'}
+  - type: Boolean
+    attributes: {id: TIMER_4_INTERRUPT_ENABLE_UPDATE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: core, value: 'false'}
+  - type: String
+    attributes: {id: TIMER_4_INTERRUPT_HANDLER}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: TIMER_4_InterruptHandler}
+  - type: Boolean
+    attributes: {id: TIMER_4_INTERRUPT_HANDLER_LOCK}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: 'true'}
+  - type: Boolean
     attributes: {id: TMR1_CLOCK_ENABLE}
     children:
     - type: Values
@@ -1993,13 +2084,20 @@ children:
       children:
       - type: Dynamic
         attributes: {id: core, value: '120000000'}
+  - type: Boolean
+    attributes: {id: TMR4_CLOCK_ENABLE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: 'true'}
   - type: Integer
     attributes: {id: TMR4_CLOCK_FREQUENCY}
     children:
     - type: Values
       children:
       - type: Dynamic
-        attributes: {id: core, value: '0'}
+        attributes: {id: core, value: '120000000'}
   - type: Integer
     attributes: {id: TMR5_CLOCK_FREQUENCY}
     children:

--- a/firmware/motion_board/firmware/src/config/default/default.mhc/project.yml
+++ b/firmware/motion_board/firmware/src/config/default/default.mhc/project.yml
@@ -6,20 +6,20 @@ files:
   security: NON_SECURE
   type: SOURCE
   userChecksum: 99DB74296DF9943C474F4F03A700C790
-- generatedChecksum: B8F3F735EE1CEE3269FFCDBF7ADC1F09
+- generatedChecksum: DB8BD9CBB7082784B9F9F3B07D3E7D59
   logicalPath: config/default
   name: initialization.c
   physicalPath: ''
   security: NON_SECURE
   type: SOURCE
-  userChecksum: B8F3F735EE1CEE3269FFCDBF7ADC1F09
-- generatedChecksum: BCF57314FF2735F6BEFDA713FAC891FE
+  userChecksum: DB8BD9CBB7082784B9F9F3B07D3E7D59
+- generatedChecksum: D2FEC5532B066B73C7B6404263E209E5
   logicalPath: config/default
   name: interrupts.c
   physicalPath: ''
   security: NON_SECURE
   type: SOURCE
-  userChecksum: 86F8A34A85A2574F0BD9B3313B183A14
+  userChecksum: 5398D24B062DA13E1108FF82D991952A
 - generatedChecksum: null
   logicalPath: ''
   name: main.c
@@ -34,13 +34,13 @@ files:
   security: NON_SECURE
   type: SOURCE
   userChecksum: 2E8E600498F7CCBC6E62120652A4C4FA
-- generatedChecksum: C6906ACF0969491204867AD67FA5170C
+- generatedChecksum: 7CCE5BB8B86E68C9CCE564977C697205
   logicalPath: config/default/peripheral/clk
   name: plib_clk.c
   physicalPath: peripheral/clk
   security: NON_SECURE
   type: SOURCE
-  userChecksum: C6906ACF0969491204867AD67FA5170C
+  userChecksum: 7CCE5BB8B86E68C9CCE564977C697205
 - generatedChecksum: F8BB2BAA74068083A80E6E229BBCF3E3
   logicalPath: config/default/peripheral/coretimer
   name: plib_coretimer.c
@@ -48,13 +48,13 @@ files:
   security: NON_SECURE
   type: SOURCE
   userChecksum: F8BB2BAA74068083A80E6E229BBCF3E3
-- generatedChecksum: 785A8B98003729EB60AD1EA1E17DFE64
+- generatedChecksum: 40B5A9020F418C0A4FB808B2E84B4FCB
   logicalPath: config/default/peripheral/evic
   name: plib_evic.c
   physicalPath: peripheral/evic
   security: NON_SECURE
   type: SOURCE
-  userChecksum: 785A8B98003729EB60AD1EA1E17DFE64
+  userChecksum: 40B5A9020F418C0A4FB808B2E84B4FCB
 - generatedChecksum: AE8A116F9ABAE440345C62E2440E1055
   logicalPath: config/default/peripheral/gpio
   name: plib_gpio.c
@@ -104,6 +104,13 @@ files:
   security: NON_SECURE
   type: SOURCE
   userChecksum: BE08D60736D2D4C8E13D9A8F2A196961
+- generatedChecksum: 0F7BA5783E5D98EDEB17D0ECCC9028AA
+  logicalPath: config/default/peripheral/tmr
+  name: plib_tmr4.c
+  physicalPath: peripheral/tmr
+  security: NON_SECURE
+  type: SOURCE
+  userChecksum: 0F7BA5783E5D98EDEB17D0ECCC9028AA
 - generatedChecksum: 3D765497A79B2E8E9151CB2089196897
   logicalPath: config/default/peripheral/uart
   name: plib_uart3.c
@@ -118,13 +125,13 @@ files:
   security: NON_SECURE
   type: SOURCE
   userChecksum: 7806B30ECAE0D18D08CD583D8775530D
-- generatedChecksum: 7EBA1DDEBA897010C0F304D703AE66D5
+- generatedChecksum: 7F640DFB7D02F319004DEF885C106ACC
   logicalPath: config/default
   name: definitions.h
   physicalPath: ''
   security: NON_SECURE
   type: HEADER
-  userChecksum: 7EBA1DDEBA897010C0F304D703AE66D5
+  userChecksum: 7F640DFB7D02F319004DEF885C106ACC
 - generatedChecksum: E189C26B2269F8DE46033CCD0621958D
   logicalPath: config/default
   name: device.h
@@ -237,6 +244,13 @@ files:
   security: NON_SECURE
   type: HEADER
   userChecksum: AB441E032FD7B269DB6B2AA5661A890C
+- generatedChecksum: D4D90D177F70F2159F886B9C3690CA49
+  logicalPath: config/default/peripheral/tmr
+  name: plib_tmr4.h
+  physicalPath: peripheral/tmr
+  security: NON_SECURE
+  type: HEADER
+  userChecksum: D4D90D177F70F2159F886B9C3690CA49
 - generatedChecksum: D948F2CE092CAB556EF299D3CCD83A55
   logicalPath: config/default/peripheral/tmr
   name: plib_tmr_common.h

--- a/firmware/motion_board/firmware/src/config/default/default.mhc/tmr4.yml
+++ b/firmware/motion_board/firmware/src/config/default/default.mhc/tmr4.yml
@@ -1,0 +1,76 @@
+format_version: v1.0
+type: UniqueComponent
+attributes: {id: tmr4}
+children:
+- type: Symbols
+  children:
+  - type: Hex
+    attributes: {id: TCON_REG_VALUE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: '8'}
+  - type: KeyValueSet
+    attributes: {id: TIMER_32BIT_MODE_SEL}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '0'}
+  - type: Integer
+    attributes: {id: TIMER_CLOCK_FREQ}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: '120000000'}
+  - type: Long
+    attributes: {id: TIMER_PERIOD}
+    children:
+    - type: Attributes
+      children:
+      - type: Long
+        attributes: {id: max}
+        children:
+        - {type: Value, value: '4294967295'}
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: '2399999'}
+  - type: KeyValueSet
+    attributes: {id: TIMER_PRE_SCALER}
+    children:
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '7'}
+  - type: Float
+    attributes: {id: TIMER_TIME_PERIOD_MS}
+    children:
+    - type: Attributes
+      children:
+      - type: Float
+        attributes: {id: max}
+        children:
+        - {type: Value, value: '35791.395'}
+    - type: Values
+      children:
+      - type: User
+        attributes: {value: '20.0'}
+  - type: Integer
+    attributes: {id: TIMER_WIDTH}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: '32'}
+  - type: Integer
+    attributes: {id: TMR_PRESCALER_VALUE}
+    children:
+    - type: Values
+      children:
+      - type: Dynamic
+        attributes: {id: tmr4, value: '1'}
+- type: ElementPosition
+  attributes: {x: '346', y: '111', id: tmr4}

--- a/firmware/motion_board/firmware/src/config/default/definitions.h
+++ b/firmware/motion_board/firmware/src/config/default/definitions.h
@@ -51,6 +51,7 @@
 #include "peripheral/coretimer/plib_coretimer.h"
 #include "peripheral/uart/plib_uart3.h"
 #include "peripheral/qei/plib_qei1.h"
+#include "peripheral/tmr/plib_tmr4.h"
 #include "peripheral/can/plib_can4.h"
 #include "peripheral/qei/plib_qei3.h"
 #include "peripheral/tmr/plib_tmr2.h"

--- a/firmware/motion_board/firmware/src/config/default/harmony-manifest-success.yml
+++ b/firmware/motion_board/firmware/src/config/default/harmony-manifest-success.yml
@@ -4,7 +4,7 @@
 
 
 project: motion_board
-creation_date: 2021-11-11T12:41:36.398+01:00[Europe/Prague]    # ISO 8601 format: https://www.w3.org/TR/NOTE-datetime
+creation_date: 2021-11-16T22:57:54.911+01:00[Europe/Prague]    # ISO 8601 format: https://www.w3.org/TR/NOTE-datetime
 operating_system: Windows 10
 mhc_mode: IDE            # [IDE|Standalone|Headless]
 mhc_version: v3.8.1

--- a/firmware/motion_board/firmware/src/config/default/initialization.c
+++ b/firmware/motion_board/firmware/src/config/default/initialization.c
@@ -190,6 +190,8 @@ void SYS_Initialize ( void* data )
 
     QEI1_Initialize();
 
+    TMR4_Initialize();
+
     CAN4_Initialize();
 
     QEI3_Initialize();

--- a/firmware/motion_board/firmware/src/config/default/peripheral/evic/plib_evic.c
+++ b/firmware/motion_board/firmware/src/config/default/peripheral/evic/plib_evic.c
@@ -55,8 +55,9 @@ void EVIC_Initialize( void )
     INTCONSET = _INTCON_MVEC_MASK;
 
     /* Set up priority and subpriority of enabled interrupts */
-    IPC2SET = 0x400 | 0x0;  /* TIMER_2:  Priority 1 / Subpriority 0 */
-    IPC3SET = 0x40000 | 0x0;  /* TIMER_3:  Priority 1 / Subpriority 0 */
+    IPC2SET = 0x1000 | 0x0;  /* TIMER_2:  Priority 4 / Subpriority 0 */
+    IPC3SET = 0x80000 | 0x0;  /* TIMER_3:  Priority 2 / Subpriority 0 */
+    IPC4SET = 0xc000000 | 0x0;  /* TIMER_4:  Priority 3 / Subpriority 0 */
     IPC15SET = 0x40000 | 0x0;  /* UART3_FAULT:  Priority 1 / Subpriority 0 */
     IPC15SET = 0x4000000 | 0x0;  /* UART3_RX:  Priority 1 / Subpriority 0 */
     IPC16SET = 0x4 | 0x0;  /* UART3_TX:  Priority 1 / Subpriority 0 */

--- a/firmware/motion_board/firmware/src/config/default/peripheral/tmr/plib_tmr4.c
+++ b/firmware/motion_board/firmware/src/config/default/peripheral/tmr/plib_tmr4.c
@@ -1,0 +1,146 @@
+/*******************************************************************************
+  TMR Peripheral Library Interface Source File
+
+  Company
+    Microchip Technology Inc.
+
+  File Name
+    plib_tmr4.c
+
+  Summary
+    TMR4 peripheral library source file.
+
+  Description
+    This file implements the interface to the TMR peripheral library.  This
+    library provides access to and control of the associated peripheral
+    instance.
+
+*******************************************************************************/
+
+// DOM-IGNORE-BEGIN
+/*******************************************************************************
+* Copyright (C) 2019 Microchip Technology Inc. and its subsidiaries.
+*
+* Subject to your compliance with these terms, you may use Microchip software
+* and any derivatives exclusively with Microchip products. It is your
+* responsibility to comply with third party license terms applicable to your
+* use of third party software (including open source software) that may
+* accompany Microchip software.
+*
+* THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER
+* EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY IMPLIED
+* WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS FOR A
+* PARTICULAR PURPOSE.
+*
+* IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE,
+* INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND
+* WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS
+* BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO THE
+* FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN
+* ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+* THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+*******************************************************************************/
+// DOM-IGNORE-END
+
+
+// *****************************************************************************
+// *****************************************************************************
+// Section: Included Files
+// *****************************************************************************
+// *****************************************************************************
+
+#include "device.h"
+#include "plib_tmr4.h"
+
+static TMR_TIMER_OBJECT tmr4Obj;
+
+
+void TMR4_Initialize(void)
+{
+    /* Disable Timer */
+    T4CONCLR = _T4CON_ON_MASK;
+
+    /*
+    SIDL = 0
+    SYNC = 0
+    TGATE = 0
+    TCKPS =0
+    T32   = 1
+    TCS = 0
+    */
+    T4CONSET = 0x8;
+
+    /* Clear counter */
+    TMR4 = 0x0;
+
+    /*Set period */
+    PR4 = 2399999U;
+
+    IEC0SET = _IEC0_T4IE_MASK;
+
+}
+
+
+void TMR4_Start(void)
+{
+    T4CONSET = _T4CON_ON_MASK;
+}
+
+
+void TMR4_Stop (void)
+{
+    T4CONCLR = _T4CON_ON_MASK;
+}
+
+void TMR4_PeriodSet(uint32_t period)
+{
+    PR4  = period;
+}
+
+uint32_t TMR4_PeriodGet(void)
+{
+    return PR4;
+}
+
+uint32_t TMR4_CounterGet(void)
+{
+    return (TMR4);
+}
+
+
+uint32_t TMR4_FrequencyGet(void)
+{
+    return (120000000);
+}
+
+void TIMER_4_InterruptHandler (void)
+{
+    uint32_t status = IFS0bits.T4IF;
+    IFS0CLR = _IFS0_T4IF_MASK;
+
+    if((tmr4Obj.callback_fn != NULL))
+    {
+        tmr4Obj.callback_fn(status, tmr4Obj.context);
+    }
+}
+
+
+void TMR4_InterruptEnable(void)
+{
+
+    IEC0SET = _IEC0_T4IE_MASK;
+}
+
+
+void TMR4_InterruptDisable(void)
+{
+    IEC0CLR = _IEC0_T4IE_MASK;
+}
+
+
+void TMR4_CallbackRegister( TMR_CALLBACK callback_fn, uintptr_t context )
+{
+    /* Save callback_fn and context in local memory */
+    tmr4Obj.callback_fn = callback_fn;
+    tmr4Obj.context = context;
+}

--- a/firmware/motion_board/firmware/src/config/default/peripheral/tmr/plib_tmr4.h
+++ b/firmware/motion_board/firmware/src/config/default/peripheral/tmr/plib_tmr4.h
@@ -1,27 +1,20 @@
 /*******************************************************************************
-  SYS CLK Static Functions for Clock System Service
+  Data Type definition of Timer PLIB
 
   Company:
     Microchip Technology Inc.
 
   File Name:
-    plib_clk.c
+    plib_tmr4.h
 
   Summary:
-    SYS CLK static function implementations for the Clock System Service.
+    Data Type definition of the Timer Peripheral Interface Plib.
 
   Description:
-    The Clock System Service provides a simple interface to manage the
-    oscillators on Microchip microcontrollers. This file defines the static
-    implementation for the Clock System Service.
+    This file defines the Data Types for the Timer Plib.
 
   Remarks:
-    Static functions incorporate all system clock configuration settings as
-    determined by the user via the Microchip Harmony Configurator GUI.
-    It provides static version of the routines, eliminating the need for an
-    object ID or object handle.
-
-    Static single-open interfaces also eliminate the need for the open handle.
+    None.
 
 *******************************************************************************/
 
@@ -48,75 +41,60 @@
 * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
 *******************************************************************************/
 
-// *****************************************************************************
-// *****************************************************************************
-// Section: Include Files
-// *****************************************************************************
-// *****************************************************************************
+#ifndef PLIB_TMR4_H
+#define PLIB_TMR4_H
 
+#include <stddef.h>
+#include <stdint.h>
 #include "device.h"
-#include "plib_clk.h"
+#include "plib_tmr_common.h"
+
+// DOM-IGNORE-BEGIN
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    extern "C" {
+
+#endif
+// DOM-IGNORE-END
 
 // *****************************************************************************
 // *****************************************************************************
-// Section: File Scope Functions
+// Section: Data Types
 // *****************************************************************************
 // *****************************************************************************
 
 // *****************************************************************************
-/* Function:
-    void CLK_Initialize( void )
+// *****************************************************************************
+// Section: Interface Routines
+// *****************************************************************************
+// *****************************************************************************
 
-  Summary:
-    Initializes hardware and internal data structure of the System Clock.
+// *****************************************************************************
+void TMR4_Initialize(void);
 
-  Description:
-    This function initializes the hardware and internal data structure of System
-    Clock Service.
+void TMR4_Start(void);
 
-  Remarks:
-    This is configuration values for the static version of the Clock System
-    Service module is determined by the user via the MHC GUI.
+void TMR4_Stop(void);
 
-    The objective is to eliminate the user's need to be knowledgeable in the
-    function of the 'configuration bits' to configure the system oscillators.
-*/
+void TMR4_PeriodSet(uint32_t);
 
-void CLK_Initialize( void )
-{
-    /* unlock system for clock configuration */
-    SYSKEY = 0x00000000;
-    SYSKEY = 0xAA996655;
-    SYSKEY = 0x556699AA;
+uint32_t TMR4_PeriodGet(void);
 
- 
-        /* Peripheral Bus 1 is by default enabled, set its divisor */
-    PB1DIVbits.PBDIV = 0;
-    /* Peripheral Bus 2 is by default enabled, set its divisor */
-    PB2DIVbits.PBDIV = 0;
+uint32_t TMR4_CounterGet(void);
 
-    /* Peripheral Bus 3 is by default enabled, set its divisor */
-    PB3DIVbits.PBDIV = 0;
+uint32_t TMR4_FrequencyGet(void);
 
-    /* Peripheral Bus 5 is by default enabled, set its divisor */
-    PB5DIVbits.PBDIV = 0;
+void TMR4_InterruptEnable(void);
 
-  
+void TMR4_InterruptDisable(void);
 
-    /* Peripheral Module Disable Configuration */
+void TMR4_CallbackRegister( TMR_CALLBACK callback_fn, uintptr_t context );
 
-    CFGCONbits.PMDLOCK = 0;
+// DOM-IGNORE-BEGIN
+#ifdef __cplusplus  // Provide C++ Compatibility
 
-    PMD1 = 0x100371;
-    PMD2 = 0x17001f;
-    PMD3 = 0xfff9ffff;
-    PMD4 = 0xfff01f1;
-    PMD5 = 0x730f3f3b;
-    PMD6 = 0xa0d0000;
-    PMD7 = 0x0;
+    }
+#endif
+// DOM-IGNORE-END
 
-    CFGCONbits.PMDLOCK = 1;
-
-    /* Lock system since done with clock configuration */
-    SYSKEY = 0x33333333;
-}
+#endif /* PLIB_TMR4_H */

--- a/firmware/motion_board/firmware/src/control.c
+++ b/firmware/motion_board/firmware/src/control.c
@@ -38,7 +38,7 @@ void control_reset()
     pid_regulator_reset(&reg_right);
 }
 
-/*Call this at fixed frequency!!!*/
+/*Call this at fixed frequency!!! 500 Hz is default*/
 void control_interrupt()
 {
     int32_t v_left, v_right;

--- a/firmware/motion_board/firmware/src/control.c
+++ b/firmware/motion_board/firmware/src/control.c
@@ -55,20 +55,20 @@ void control_interrupt()
     motor_right_set_pwm(reg_right.command);    
 }
 
-void control_set_setpoint_left(float setpoint)
+void control_set_setpoint_left(int16_t setpoint)
 {
     reg_left.reference = setpoint;
 }
-float control_get_setpoint_left()
+int16_t control_get_setpoint_left()
 {
     return reg_left.reference;
 }
 
-void control_set_setpoint_right(float setpoint)
+void control_set_setpoint_right(int16_t setpoint)
 {
     reg_right.reference = setpoint;
 }
-float control_get_setpoint_right()
+int16_t control_get_setpoint_right()
 {
     return reg_right.reference;
 }

--- a/firmware/motion_board/firmware/src/control.h
+++ b/firmware/motion_board/firmware/src/control.h
@@ -10,11 +10,11 @@ void control_reset();
 
 void control_interrupt();
 
-void control_set_setpoint_left(float setpoint);
-float control_get_setpoint_left();
+void control_set_setpoint_left(int16_t setpoint);
+int16_t control_get_setpoint_left();
 
-void control_set_setpoint_right(float setpoint);
-float control_get_setpoint_right();
+void control_set_setpoint_right(int16_t setpoint);
+int16_t control_get_setpoint_right();
 
 /* PID parameters left*/
 void control_set_kp_left(float kp);

--- a/firmware/motion_board/firmware/src/main.c
+++ b/firmware/motion_board/firmware/src/main.c
@@ -32,6 +32,7 @@ int main(void)
     motor_init();   
     control_init();
     TMR3_Start();   // interrupt for control system (regulation)
+    TMR4_Start();   // encoder report interrupt (50 Hz)
     
 
     while (true)

--- a/firmware/motion_board/firmware/src/protocol.c
+++ b/firmware/motion_board/firmware/src/protocol.c
@@ -1,6 +1,8 @@
 #include "protocol.h"
 #include "control.h"
 
+bool report_encoders = false;
+
 /* Helper functions to pack/unpack vars to/from byte arrays */
 void protocol_pack_int16(uint8_t *buffer, int16_t val)
 {
@@ -241,6 +243,13 @@ void protocol_process_msg(uint32_t id, uint8_t length, uint8_t *data)
         QEI1_PositionCountSet(0);
         break;
     }
+    case CMD_ENABLE_ENCODER_REPORT:
+    {
+        report_encoders = true;
+        break;
+    }
+    case CMD_DISABLE_ENCODER_REPORT:
+        report_encoders = false;
     default:
         break;
     }

--- a/firmware/motion_board/firmware/src/protocol.c
+++ b/firmware/motion_board/firmware/src/protocol.c
@@ -98,8 +98,8 @@ void protocol_process_msg(uint32_t id, uint8_t length, uint8_t *data)
         int16_t setpoint_left = protocol_unpack_int16(&data[1]);
         int16_t setpoint_right = protocol_unpack_int16(&data[3]);
 
-        control_set_setpoint_left((float)setpoint_left);
-        control_set_setpoint_right((float)setpoint_right);
+        control_set_setpoint_left(setpoint_left);
+        control_set_setpoint_right(setpoint_right);
         break;
     }
     case CMD_SET_KP_LEFT:

--- a/firmware/motion_board/firmware/src/protocol.h
+++ b/firmware/motion_board/firmware/src/protocol.h
@@ -5,8 +5,8 @@
 #include <stdint.h>
 
 #define CAN_BASE_ID             0x00000200UL
-#define CAN_GENERAL_RESPONSE_ID (CAN_BASE_ID+1)
-#define CAN_ENCODER_ID          (CAN_BASE_ID+2)
+#define CAN_GENERAL_RESPONSE_ID (CAN_BASE_ID+2)
+#define CAN_ENCODER_ID          (CAN_BASE_ID+4)
 
 /*COMMANDS*/
 #define CMD_READ_ENCODERS       0x00
@@ -32,11 +32,15 @@
 #define CMD_GET_KD_RIGHT        0x0E
 /***********************************/
 
-#define CMD_MOTOR_OFF           0x0F
-#define CMD_MOTOR_ON            0x10
-#define CMD_RESET_REGULATORS    0x11
-#define CMD_RESET_ENCODERS      0x12
+#define CMD_MOTOR_OFF               0x0F
+#define CMD_MOTOR_ON                0x10
+#define CMD_RESET_REGULATORS        0x11
+#define CMD_RESET_ENCODERS          0x12
+#define CMD_ENABLE_ENCODER_REPORT   0x13
+#define CMD_DISABLE_ENCODER_REPORT  0x14
 
+
+extern bool report_encoders;
 
 void protocol_process_msg(uint32_t id, uint8_t length, uint8_t *data);
 void can_send_quick(uint32_t id, uint8_t length, uint8_t *data);

--- a/mep3_driver/CMakeLists.txt
+++ b/mep3_driver/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   ${PROJECT_NAME}
   SHARED
   src/robot_hardware_interface.cpp
+  src/motion_board_driver.cpp
 )
 
 target_include_directories(

--- a/mep3_driver/CMakeLists.txt
+++ b/mep3_driver/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.5)
+project(mep3_driver)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+
+add_library(
+  ${PROJECT_NAME}
+  SHARED
+  src/robot_hardware_interface.cpp
+)
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PRIVATE
+  include
+)
+ament_target_dependencies(
+  ${PROJECT_NAME}
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+)
+
+pluginlib_export_plugin_description_file(hardware_interface mep3_driver_ros2_control.xml)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  DESTINATION lib
+)
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+install(
+  DIRECTORY resource launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  ${PROJECT_NAME}
+)
+ament_export_dependencies(
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+)
+ament_package()

--- a/mep3_driver/README.md
+++ b/mep3_driver/README.md
@@ -1,0 +1,8 @@
+# Driver
+
+Creates ROS 2 interface on top of the physical robot. It includes the `ros2_control` integration.
+
+Run the driver:
+```bash
+ros2 launch mep3_driver driver_launch.py
+```

--- a/mep3_driver/include/mep3_driver/motion_board_driver.hpp
+++ b/mep3_driver/include/mep3_driver/motion_board_driver.hpp
@@ -1,0 +1,84 @@
+#ifndef MOTION_BOARD_DRIVER_HPP
+#define MOTION_BOARD_DRIVER_HPP
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <tuple>
+
+extern "C" {
+#include <pthread.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <unistd.h>
+}
+
+
+
+class MotionBoardDriver
+{
+    private:
+        int32_t encoder_left_;
+        int32_t encoder_right_;
+
+        int canbus_socket_;
+        struct sockaddr_can address_;
+        struct ifreq ifr_;
+
+        struct can_filter filter_;
+
+        pthread_t canbus_receive_thread_;
+        bool keep_communication_alive_;
+        pthread_mutex_t data_lock_;
+
+        static const uint32_t CAN_BASE_ID =                 0x200;
+        static const uint32_t CAN_ENCODER_ID =              0x80000204;     // 8 because we will receive MSB due to extended ID 
+
+        static const uint32_t CMD_RESET_ENCODERS =          0x12;
+        static const uint32_t CMD_ENABLE_ENCODER_REPORT =   0x13;
+        static const uint32_t CMD_DISABLE_ENCODER_REPORT =  0x14;
+        static const uint32_t CMD_SET_SETPOINTS =           0x01;
+
+        static const uint32_t CMD_SET_KP_LEFT =             0x03;
+        static const uint32_t CMD_SET_KI_LEFT =             0x05;
+        static const uint32_t CMD_SET_KD_LEFT =             0x07;
+
+        static const uint32_t CMD_SET_KP_RIGHT =            0x09;
+        static const uint32_t CMD_SET_KI_RIGHT =            0x0B;
+        static const uint32_t CMD_SET_KD_RIGHT =            0x0D;
+
+
+        static int32_t protocol_unpack_int32(uint8_t *buffer);
+        static void protocol_pack_int16(uint8_t *buffer, int16_t val);
+        static void protocol_pack_float(uint8_t *buffer, float val);
+
+    public:
+        MotionBoardDriver();
+        ~MotionBoardDriver();
+
+        int init();        
+        void start();
+        void halt();
+        static void* canbus_thread_entry(void *ptr);
+        void* canbus_receive_function();
+        std::tuple<int32_t, int32_t> get_encoders(); 
+        void reset_encoders();
+        void encoder_report_enable();
+        void encoder_report_disable();
+        void set_setpoints(int16_t left, int16_t right);
+        
+        void set_kp_left(float val);
+        void set_ki_left(float val);
+        void set_kd_left(float val);
+
+        void set_kp_right(float val);
+        void set_ki_right(float val);
+        void set_kd_right(float val);
+};
+
+
+
+#endif

--- a/mep3_driver/include/mep3_driver/motion_board_driver.hpp
+++ b/mep3_driver/include/mep3_driver/motion_board_driver.hpp
@@ -2,24 +2,23 @@
 #define MOTION_BOARD_DRIVER_HPP
 
 #include <cstdint>
-#include <cstdio>
-#include <cstring>
 #include <tuple>
 
-extern "C" {
-#include <pthread.h>
-#include <net/if.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <linux/can.h>
-#include <linux/can/raw.h>
-#include <unistd.h>
+extern "C"
+{
+#include <pthread.h>       // POSIX threads, can be switched to realtime
+#include <net/if.h>        // ifreq
+#include <sys/ioctl.h>     // IO control
+#include <sys/socket.h>    // socket library
+#include <linux/can.h>     // CAN network layer definitions
+#include <linux/can/raw.h> // CAN_RAW_FILTER
+#include <unistd.h>        // read, write to sockets, close
 }
 
-
-
-class MotionBoardDriver
+namespace mep3_driver
 {
+    class MotionBoardDriver
+    {
     private:
         int32_t encoder_left_;
         int32_t encoder_right_;
@@ -34,22 +33,21 @@ class MotionBoardDriver
         bool keep_communication_alive_;
         pthread_mutex_t data_lock_;
 
-        static const uint32_t CAN_BASE_ID =                 0x200;
-        static const uint32_t CAN_ENCODER_ID =              0x80000204;     // 8 because we will receive MSB due to extended ID 
+        static const uint32_t CAN_BASE_ID = 0x200;
+        static const uint32_t CAN_ENCODER_ID = 0x80000204; // 8 because we will receive MSB due to extended ID
 
-        static const uint32_t CMD_RESET_ENCODERS =          0x12;
-        static const uint32_t CMD_ENABLE_ENCODER_REPORT =   0x13;
-        static const uint32_t CMD_DISABLE_ENCODER_REPORT =  0x14;
-        static const uint32_t CMD_SET_SETPOINTS =           0x01;
+        static const uint32_t CMD_RESET_ENCODERS = 0x12;
+        static const uint32_t CMD_ENABLE_ENCODER_REPORT = 0x13;
+        static const uint32_t CMD_DISABLE_ENCODER_REPORT = 0x14;
+        static const uint32_t CMD_SET_SETPOINTS = 0x01;
 
-        static const uint32_t CMD_SET_KP_LEFT =             0x03;
-        static const uint32_t CMD_SET_KI_LEFT =             0x05;
-        static const uint32_t CMD_SET_KD_LEFT =             0x07;
+        static const uint32_t CMD_SET_KP_LEFT = 0x03;
+        static const uint32_t CMD_SET_KI_LEFT = 0x05;
+        static const uint32_t CMD_SET_KD_LEFT = 0x07;
 
-        static const uint32_t CMD_SET_KP_RIGHT =            0x09;
-        static const uint32_t CMD_SET_KI_RIGHT =            0x0B;
-        static const uint32_t CMD_SET_KD_RIGHT =            0x0D;
-
+        static const uint32_t CMD_SET_KP_RIGHT = 0x09;
+        static const uint32_t CMD_SET_KI_RIGHT = 0x0B;
+        static const uint32_t CMD_SET_KD_RIGHT = 0x0D;
 
         static int32_t protocol_unpack_int32(uint8_t *buffer);
         static void protocol_pack_int16(uint8_t *buffer, int16_t val);
@@ -59,17 +57,17 @@ class MotionBoardDriver
         MotionBoardDriver();
         ~MotionBoardDriver();
 
-        int init();        
+        int init();
         void start();
         void halt();
-        static void* canbus_thread_entry(void *ptr);
-        void* canbus_receive_function();
-        std::tuple<int32_t, int32_t> get_encoders(); 
+        static void *canbus_thread_entry(void *ptr);
+        void *canbus_receive_function();
+        std::tuple<int32_t, int32_t> get_encoders();
         void reset_encoders();
         void encoder_report_enable();
         void encoder_report_disable();
         void set_setpoints(int16_t left, int16_t right);
-        
+
         void set_kp_left(float val);
         void set_ki_left(float val);
         void set_kd_left(float val);
@@ -77,8 +75,7 @@ class MotionBoardDriver
         void set_kp_right(float val);
         void set_ki_right(float val);
         void set_kd_right(float val);
-};
-
-
+    };
+}
 
 #endif

--- a/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
+++ b/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
@@ -8,6 +8,10 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 
+#include "motion_board_driver.hpp"
+
+#define POW2(N) (1UL << (N))
+
 namespace mep3_driver
 {
     class RobotHardwareInterface : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
@@ -26,6 +30,18 @@ namespace mep3_driver
         double mLeftWheelPositionState;
         double mRightWheelVelocityCommand;
         double mRightWheelPositionState;
+
+        int32_t mPrevLeftWheelRaw;
+        int32_t mPrevRightWheelRaw;
+        int mOdomLeftOverflow;
+        int mOdomRightOverflow;
+
+        float kp_left_, ki_left_, kd_left_;
+        float kp_right_, ki_right_, kd_right_;
+
+        static constexpr double ENCODER_RESOLUTION = 8192.0;   // 2048 * 4
+
+        MotionBoardDriver motion_board_;
     };
 }
 

--- a/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
+++ b/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
@@ -1,0 +1,32 @@
+#ifndef ROBOT_HARDWARE_INTERFACE_HPP
+#define ROBOT_HARDWARE_INTERFACE_HPP
+
+#include "hardware_interface/base_interface.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+
+namespace mep3_driver
+{
+    class RobotHardwareInterface : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+    {
+    public:
+        hardware_interface::return_type configure(const hardware_interface::HardwareInfo &info) override;
+        hardware_interface::return_type start() override;
+        hardware_interface::return_type stop() override;
+        std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+        std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+        hardware_interface::return_type read() override;
+        hardware_interface::return_type write() override;
+
+    private:
+        double mLeftWheelVelocityCommand;
+        double mLeftWheelPositionState;
+        double mRightWheelVelocityCommand;
+        double mRightWheelPositionState;
+    };
+}
+
+#endif

--- a/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
+++ b/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
@@ -26,20 +26,20 @@ namespace mep3_driver
         hardware_interface::return_type write() override;
 
     private:
-        double mLeftWheelVelocityCommand;
-        double mLeftWheelPositionState;
-        double mRightWheelVelocityCommand;
-        double mRightWheelPositionState;
+        double left_wheel_velocity_command_;
+        double left_wheel_position_state_;
+        double right_wheel_velocity_command_;
+        double right_wheel_position_state_;
 
-        int32_t mPrevLeftWheelRaw;
-        int32_t mPrevRightWheelRaw;
-        int mOdomLeftOverflow;
-        int mOdomRightOverflow;
+        int32_t prev_left_wheel_raw_;
+        int32_t prev_right_wheel_raw_;
+        int odom_left_overflow_;
+        int odom_right_overflow_;
 
         float kp_left_, ki_left_, kd_left_;
         float kp_right_, ki_right_, kd_right_;
 
-        static constexpr double ENCODER_RESOLUTION = 8192.0;   // 2048 * 4
+        static constexpr double ENCODER_RESOLUTION = 8192.0; // 2048 * 4
 
         MotionBoardDriver motion_board_;
     };

--- a/mep3_driver/launch/driver_launch.py
+++ b/mep3_driver/launch/driver_launch.py
@@ -19,7 +19,7 @@ def generate_launch_description():
             ros2_control_params
         ],
         remappings=[
-            ('/diffdrive_controller/cmd_vel', '/cmd_vel')
+            ('/diffdrive_controller/cmd_vel_unstamped', '/cmd_vel')
         ],
         output='screen'
     )

--- a/mep3_driver/launch/driver_launch.py
+++ b/mep3_driver/launch/driver_launch.py
@@ -1,0 +1,37 @@
+import os
+import pathlib
+from launch import LaunchDescription
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    package_dir = get_package_share_directory('mep3_driver')
+
+    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'mep3_big_config.urdf')).read_text()
+    ros2_control_params = os.path.join(package_dir, 'resource', 'mep3_big_ros2_control.yaml')
+
+    controller_manager_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            {'robot_description': robot_description},
+            ros2_control_params
+        ],
+        remappings=[
+            ('/diffdrive_controller/cmd_vel', '/cmd_vel')
+        ],
+        output='screen'
+    )
+
+    diffdrive_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner.py',
+        output='screen',
+        arguments=['diffdrive_controller']
+    )
+
+    return LaunchDescription([
+        controller_manager_node,
+        diffdrive_controller_spawner
+    ])

--- a/mep3_driver/mep3_driver_ros2_control.xml
+++ b/mep3_driver/mep3_driver_ros2_control.xml
@@ -1,0 +1,3 @@
+<library path="mep3_driver">
+    <class type="mep3_driver::RobotHardwareInterface" base_class_type="hardware_interface::SystemInterface"></class>
+</library>

--- a/mep3_driver/package.xml
+++ b/mep3_driver/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>mep3_driver</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="lukicdarkoo@gmail.com">lukic</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/mep3_driver/resource/mep3_big_config.urdf
+++ b/mep3_driver/resource/mep3_big_config.urdf
@@ -3,6 +3,13 @@
     <ros2_control name="HardwareControl" type="system">
         <hardware>
             <plugin>mep3_driver::RobotHardwareInterface</plugin>
+            <param name="kp_left">120.0</param>
+            <param name="ki_left">1.5</param>
+            <param name="kd_left">0.0</param>
+
+            <param name="kp_right">120.0</param>
+            <param name="ki_right">1.5</param>
+            <param name="kd_right">0.0</param>
         </hardware>
         <joint name="left_motor">
             <state_interface name="position" />

--- a/mep3_driver/resource/mep3_big_config.urdf
+++ b/mep3_driver/resource/mep3_big_config.urdf
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<robot name="MemristorBig">
+    <ros2_control name="HardwareControl" type="system">
+        <hardware>
+            <plugin>mep3_driver::RobotHardwareInterface</plugin>
+        </hardware>
+        <joint name="left_motor">
+            <state_interface name="position" />
+            <command_interface name="velocity" />
+        </joint>
+        <joint name="right_motor">
+            <state_interface name="position" />
+            <command_interface name="velocity" />
+        </joint>
+    </ros2_control>
+</robot>

--- a/mep3_driver/resource/mep3_big_ros2_control.yaml
+++ b/mep3_driver/resource/mep3_big_ros2_control.yaml
@@ -18,10 +18,3 @@ diffdrive_controller:
 
     publish_rate: 50.0
     use_stamped_vel: false
-
-joint_state_broadcaster:
-  ros__parameters:
-    extra_joints:
-      - removal_motor   # Removal tool joint without encoder
-      - CASTER          # Non-actuated caster joint #1
-      - hingejoint      # Non-actuated caster joint #2

--- a/mep3_driver/resource/mep3_big_ros2_control.yaml
+++ b/mep3_driver/resource/mep3_big_ros2_control.yaml
@@ -1,0 +1,27 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 50
+
+    diffdrive_controller:
+      type: diff_drive_controller/DiffDriveController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+diffdrive_controller:
+  ros__parameters:
+    left_wheel_names: ["left_motor"]
+    right_wheel_names: ["right_motor"]
+
+    wheel_separation: 0.35
+    wheel_radius: 0.073
+
+    publish_rate: 50.0
+    use_stamped_vel: true
+
+joint_state_broadcaster:
+  ros__parameters:
+    extra_joints:
+      - removal_motor   # Removal tool joint without encoder
+      - CASTER          # Non-actuated caster joint #1
+      - hingejoint      # Non-actuated caster joint #2

--- a/mep3_driver/resource/mep3_big_ros2_control.yaml
+++ b/mep3_driver/resource/mep3_big_ros2_control.yaml
@@ -17,7 +17,7 @@ diffdrive_controller:
     wheel_radius: 0.073
 
     publish_rate: 50.0
-    use_stamped_vel: true
+    use_stamped_vel: false
 
 joint_state_broadcaster:
   ros__parameters:

--- a/mep3_driver/src/motion_board_driver.cpp
+++ b/mep3_driver/src/motion_board_driver.cpp
@@ -1,254 +1,257 @@
 #include "mep3_driver/motion_board_driver.hpp"
 
+#include <cstdio>
+#include <iostream>
+#include <cstring>
 
-MotionBoardDriver::MotionBoardDriver()
+namespace mep3_driver
 {
-    encoder_left_ = 0;
-    encoder_right_ = 0;
-}
-
-MotionBoardDriver::~MotionBoardDriver()
-{
-    halt();
-}
-
-int MotionBoardDriver::init()
-{
-    pthread_mutex_init(&data_lock_, NULL);
-    
-    if ((canbus_socket_ = socket(PF_CAN, SOCK_RAW, CAN_RAW_FILTER)) < 0) 
+    MotionBoardDriver::MotionBoardDriver()
     {
-		perror("Socket");
-		return 1;
-	}
-
-    filter_.can_id = 0x80000204;
-    filter_.can_mask = 0x1FFFFFFF;
-
-    if (setsockopt(canbus_socket_, SOL_CAN_RAW, CAN_RAW_FILTER, &filter_, sizeof(filter_)) < 0)
-    {
-        perror("Can filter setsockopt failed!");
-        return 1;
+        encoder_left_ = 0;
+        encoder_right_ = 0;
     }
 
-    struct timeval timeout;
-    timeout.tv_sec = 1;
-    timeout.tv_usec = 0;
-
-    if (setsockopt(canbus_socket_, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0)
+    MotionBoardDriver::~MotionBoardDriver()
     {
-        perror("Can filter setsockopt failed!");
-        return 1;
+        halt();
     }
 
-    memset(&ifr_, 0, sizeof(ifr_));
-    strcpy(ifr_.ifr_name, "can0");
-	ioctl(canbus_socket_, SIOCGIFINDEX, &ifr_);
-
-    address_.can_family = AF_CAN;
-    address_.can_ifindex = ifr_.ifr_ifindex;
-
-    if (bind(canbus_socket_, (struct sockaddr *)&address_, sizeof(address_)) < 0)
+    int MotionBoardDriver::init()
     {
-		perror("Bind");
-		return 1;
-	}
+        pthread_mutex_init(&data_lock_, NULL);
 
-    reset_encoders();
-
-    return 0;
-}
-
-void MotionBoardDriver::start()
-{
-    int ret = pthread_create(&canbus_receive_thread_, NULL, canbus_thread_entry, this);
-    if (ret != 0)
-    {
-        perror("Failed to create canbus receive thread!\n");
-    }
-    encoder_report_enable();
-}
-
-void MotionBoardDriver::halt()
-{
-    encoder_report_disable();
-    printf("Calling CANCEL\n");
-    pthread_cancel(canbus_receive_thread_);
-    pthread_join(canbus_receive_thread_, NULL);
-    printf("Thread terminated!\n");
-}
-
-void* MotionBoardDriver::canbus_thread_entry(void *ptr)
-{
-    return reinterpret_cast<MotionBoardDriver*>(ptr)->canbus_receive_function();
-}
-
-
-void* MotionBoardDriver::canbus_receive_function()
-{
-    for (;;)
-    {
-        struct can_frame frame;
-        int nbytes = read(canbus_socket_, &frame, sizeof(struct can_frame));        
-
-        if (nbytes > 0)
+        if ((canbus_socket_ = socket(PF_CAN, SOCK_RAW, CAN_RAW_FILTER)) < 0)
         {
-            if (frame.can_id == CAN_ENCODER_ID && frame.can_dlc == 8)
-            {   
-                int32_t left;
-                int32_t right;
-                left = protocol_unpack_int32(&frame.data[0]);
-                right = protocol_unpack_int32(&frame.data[4]);
-                
-                pthread_mutex_lock(&data_lock_);
-                encoder_left_ = left;
-                encoder_right_ = right;
-                pthread_mutex_unlock(&data_lock_);
+            std::cerr << "Socket error!\n";
+            return 1;
+        }
+
+        filter_.can_id = CAN_ENCODER_ID;
+        filter_.can_mask = 0x1FFFFFFF;
+
+        if (setsockopt(canbus_socket_, SOL_CAN_RAW, CAN_RAW_FILTER, &filter_, sizeof(filter_)) < 0)
+        {
+            std::cerr << "Can filter setsockopt failed!\n";
+            return 1;
+        }
+
+        struct timeval timeout;
+        timeout.tv_sec = 1;
+        timeout.tv_usec = 0;
+
+        if (setsockopt(canbus_socket_, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0)
+        {
+            std::cerr << "Can filter setsockopt failed!\n";
+            return 1;
+        }
+
+        memset(&ifr_, 0, sizeof(ifr_));
+        strcpy(ifr_.ifr_name, "can0");
+        ioctl(canbus_socket_, SIOCGIFINDEX, &ifr_);
+
+        address_.can_family = AF_CAN;
+        address_.can_ifindex = ifr_.ifr_ifindex;
+
+        if (bind(canbus_socket_, (struct sockaddr *)&address_, sizeof(address_)) < 0)
+        {
+            std::cerr << "Bind error!\n";
+            return 1;
+        }
+
+        reset_encoders();
+
+        return 0;
+    }
+
+    void MotionBoardDriver::start()
+    {
+        int ret = pthread_create(&canbus_receive_thread_, NULL, canbus_thread_entry, this);
+        if (ret != 0)
+        {
+            std::cerr << "Failed to create canbus receive thread!\n";
+        }
+        encoder_report_enable();
+    }
+
+    void MotionBoardDriver::halt()
+    {
+        encoder_report_disable();
+
+        pthread_cancel(canbus_receive_thread_);
+        pthread_join(canbus_receive_thread_, NULL);
+
+        close(canbus_socket_);
+    }
+
+    void *MotionBoardDriver::canbus_thread_entry(void *ptr)
+    {
+        return reinterpret_cast<MotionBoardDriver *>(ptr)->canbus_receive_function();
+    }
+
+    void *MotionBoardDriver::canbus_receive_function()
+    {
+        for (;;)
+        {
+            struct can_frame frame;
+            const int nbytes = read(canbus_socket_, &frame, sizeof(struct can_frame));
+
+            if (nbytes > 0)
+            {
+                if (frame.can_id == CAN_ENCODER_ID && frame.can_dlc == 8)
+                {
+                    const int32_t left = protocol_unpack_int32(&frame.data[0]);
+                    const int32_t right = protocol_unpack_int32(&frame.data[4]);
+
+                    pthread_mutex_lock(&data_lock_);
+                    encoder_left_ = left;
+                    encoder_right_ = right;
+                    pthread_mutex_unlock(&data_lock_);
+                }
             }
         }
+        return NULL;
     }
-    return NULL;
-}
 
-
-int32_t MotionBoardDriver::protocol_unpack_int32(uint8_t *buffer)
-{
-    int32_t val = 0;
-    for (int i = 0; i < 4; i++)
+    int32_t MotionBoardDriver::protocol_unpack_int32(uint8_t *buffer)
     {
-        val |= ((uint32_t) buffer[i] << 8 * (3 - i));
+        int32_t val = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            val |= ((uint32_t)buffer[i] << 8 * (3 - i));
+        }
+
+        return val;
     }
 
-    return val;
-}
-
-void MotionBoardDriver::protocol_pack_int16(uint8_t *buffer, int16_t val)
-{
-    buffer[1] = val & 0xFF;
-    buffer[0] = (val >> 8) & 0xFF;
-}
-
-void MotionBoardDriver::protocol_pack_float(uint8_t *buffer, float val)
-{
-    uint32_t as_integer = *((uint32_t *) & val); // access float on byte level
-    for (int i = 3; i >= 0; i--)
+    void MotionBoardDriver::protocol_pack_int16(uint8_t *buffer, int16_t val)
     {
-        buffer[i] = (as_integer >> 8 * (3 - i)) & 0xFF;
+        buffer[1] = val & 0xFF;
+        buffer[0] = (val >> 8) & 0xFF;
     }
-}
 
-std::tuple<int32_t, int32_t> MotionBoardDriver::get_encoders()
-{
-    pthread_mutex_lock(&data_lock_);
-    int32_t left = encoder_left_;
-    int32_t right = encoder_right_;
-    pthread_mutex_unlock(&data_lock_);
+    void MotionBoardDriver::protocol_pack_float(uint8_t *buffer, float val)
+    {
+        uint32_t as_integer = *((uint32_t *)&val); // access float on byte level
+        for (int i = 3; i >= 0; i--)
+        {
+            buffer[i] = (as_integer >> 8 * (3 - i)) & 0xFF;
+        }
+    }
 
-    return std::make_tuple(left, right);
-}
+    std::tuple<int32_t, int32_t> MotionBoardDriver::get_encoders()
+    {
+        pthread_mutex_lock(&data_lock_);
+        int32_t left = encoder_left_;
+        int32_t right = encoder_right_;
+        pthread_mutex_unlock(&data_lock_);
 
-void MotionBoardDriver::reset_encoders()
-{
-    struct can_frame frame;
-    frame.can_id = 0x200;
-    frame.can_dlc = 1;
-    frame.data[0] = CMD_RESET_ENCODERS;
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+        return std::make_tuple(left, right);
+    }
 
-void MotionBoardDriver::encoder_report_enable()
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 1;
-    frame.data[0] = CMD_ENABLE_ENCODER_REPORT;
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::reset_encoders()
+    {
+        struct can_frame frame;
+        frame.can_id = 0x200;
+        frame.can_dlc = 1;
+        frame.data[0] = CMD_RESET_ENCODERS;
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-void MotionBoardDriver::encoder_report_disable()
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 1;
-    frame.data[0] = CMD_DISABLE_ENCODER_REPORT;
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::encoder_report_enable()
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 1;
+        frame.data[0] = CMD_ENABLE_ENCODER_REPORT;
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-void MotionBoardDriver::set_setpoints(int16_t left, int16_t right)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_SETPOINTS;
+    void MotionBoardDriver::encoder_report_disable()
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 1;
+        frame.data[0] = CMD_DISABLE_ENCODER_REPORT;
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    protocol_pack_int16(&frame.data[1], left);
-    protocol_pack_int16(&frame.data[3], right);
+    void MotionBoardDriver::set_setpoints(int16_t left, int16_t right)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_SETPOINTS;
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+        protocol_pack_int16(&frame.data[1], left);
+        protocol_pack_int16(&frame.data[3], right);
 
-void MotionBoardDriver::set_kp_left(float val)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_KP_LEFT;
-    protocol_pack_float(&frame.data[1], val);
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::set_kp_left(float val)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_KP_LEFT;
+        protocol_pack_float(&frame.data[1], val);
 
-void MotionBoardDriver::set_ki_left(float val)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_KI_LEFT;
-    protocol_pack_float(&frame.data[1], val);
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::set_ki_left(float val)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_KI_LEFT;
+        protocol_pack_float(&frame.data[1], val);
 
-void MotionBoardDriver::set_kd_left(float val)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_KD_LEFT;
-    protocol_pack_float(&frame.data[1], val);
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::set_kd_left(float val)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_KD_LEFT;
+        protocol_pack_float(&frame.data[1], val);
 
-void MotionBoardDriver::set_kp_right(float val)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_KP_RIGHT;
-    protocol_pack_float(&frame.data[1], val);
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::set_kp_right(float val)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_KP_RIGHT;
+        protocol_pack_float(&frame.data[1], val);
 
-void MotionBoardDriver::set_ki_right(float val)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_KI_RIGHT;
-    protocol_pack_float(&frame.data[1], val);
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
-}
+    void MotionBoardDriver::set_ki_right(float val)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_KI_RIGHT;
+        protocol_pack_float(&frame.data[1], val);
 
-void MotionBoardDriver::set_kd_right(float val)
-{
-    struct can_frame frame;
-    frame.can_id = CAN_BASE_ID;
-    frame.can_dlc = 5;
-    frame.data[0] = CMD_SET_KD_RIGHT;
-    protocol_pack_float(&frame.data[1], val);
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 
-    write(canbus_socket_, &frame, sizeof(struct can_frame));
+    void MotionBoardDriver::set_kd_right(float val)
+    {
+        struct can_frame frame;
+        frame.can_id = CAN_BASE_ID;
+        frame.can_dlc = 5;
+        frame.data[0] = CMD_SET_KD_RIGHT;
+        protocol_pack_float(&frame.data[1], val);
+
+        write(canbus_socket_, &frame, sizeof(struct can_frame));
+    }
 }

--- a/mep3_driver/src/robot_hardware_interface.cpp
+++ b/mep3_driver/src/robot_hardware_interface.cpp
@@ -1,0 +1,66 @@
+#include "mep3_driver/robot_hardware_interface.hpp"
+
+#include <iostream>
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+namespace mep3_driver
+{
+    hardware_interface::return_type RobotHardwareInterface::configure(const hardware_interface::HardwareInfo &info)
+    {
+        if (configure_default(info) != hardware_interface::return_type::OK)
+        {
+            return hardware_interface::return_type::ERROR;
+        }
+        status_ = hardware_interface::status::CONFIGURED;
+        return hardware_interface::return_type::OK;
+    }
+
+    hardware_interface::return_type RobotHardwareInterface::start()
+    {
+        status_ = hardware_interface::status::STARTED;
+        return hardware_interface::return_type::OK;
+    }
+
+    hardware_interface::return_type RobotHardwareInterface::stop()
+    {
+        status_ = hardware_interface::status::STOPPED;
+        return hardware_interface::return_type::OK;
+    }
+
+    std::vector<hardware_interface::StateInterface> RobotHardwareInterface::export_state_interfaces()
+    {
+        std::vector<hardware_interface::StateInterface> interfaces;
+        interfaces.emplace_back(hardware_interface::StateInterface("left_motor", hardware_interface::HW_IF_POSITION, &mLeftWheelPositionState));
+        interfaces.emplace_back(hardware_interface::StateInterface("right_motor", hardware_interface::HW_IF_POSITION, &mRightWheelPositionState));
+        return interfaces;
+    }
+
+    std::vector<hardware_interface::CommandInterface> RobotHardwareInterface::export_command_interfaces()
+    {
+        std::vector<hardware_interface::CommandInterface> interfaces;
+        interfaces.emplace_back(hardware_interface::CommandInterface("left_motor", hardware_interface::HW_IF_VELOCITY, &mLeftWheelVelocityCommand));
+        interfaces.emplace_back(hardware_interface::CommandInterface("right_motor", hardware_interface::HW_IF_VELOCITY, &mRightWheelVelocityCommand));
+        return interfaces;
+    }
+
+    hardware_interface::return_type RobotHardwareInterface::read()
+    {
+        // Read encoder data from the robot
+        mLeftWheelPositionState = 0;
+        mRightWheelPositionState = 0;
+
+        return hardware_interface::return_type::OK;
+    }
+
+    hardware_interface::return_type RobotHardwareInterface::write()
+    {
+        // Send left and right wheel velocity commands to the robot
+        std::cout << "mLeftWheelVelocityCommand: " << mLeftWheelVelocityCommand << std::endl;
+        std::cout << "mRightWheelVelocityCommand: " << mRightWheelVelocityCommand << std::endl;
+
+        return hardware_interface::return_type::OK;
+    }
+}
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(mep3_driver::RobotHardwareInterface, hardware_interface::SystemInterface)

--- a/mep3_driver/src/robot_hardware_interface.cpp
+++ b/mep3_driver/src/robot_hardware_interface.cpp
@@ -3,6 +3,9 @@
 #include <iostream>
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
+#include <cmath>
+#include <cstring>
+
 namespace mep3_driver
 {
     hardware_interface::return_type RobotHardwareInterface::configure(const hardware_interface::HardwareInfo &info)
@@ -11,6 +14,19 @@ namespace mep3_driver
         {
             return hardware_interface::return_type::ERROR;
         }
+
+        kp_left_ = std::stof(info_.hardware_parameters["kp_left"]);
+        ki_left_ = std::stof(info_.hardware_parameters["ki_left"]);
+        kd_left_ = std::stof(info_.hardware_parameters["kd_left"]);
+
+        kp_right_ = std::stof(info_.hardware_parameters["kp_right"]);
+        ki_right_ = std::stof(info_.hardware_parameters["ki_right"]);
+        kd_right_ = std::stof(info_.hardware_parameters["kd_right"]);
+
+        std::cout << "KP Left: " << kp_left_ << "\tKI Left: " << ki_left_ << "\tKD Left: " << kd_left_ << std::endl;
+        std::cout << "KP Left: " << kp_right_ << "\tKI_Right: " << ki_right_ << "\tKD Right: " << kd_right_ << std::endl;
+
+
         status_ = hardware_interface::status::CONFIGURED;
         return hardware_interface::return_type::OK;
     }
@@ -18,12 +34,37 @@ namespace mep3_driver
     hardware_interface::return_type RobotHardwareInterface::start()
     {
         status_ = hardware_interface::status::STARTED;
+
+        // init variables
+        mLeftWheelVelocityCommand = 0;
+        mLeftWheelPositionState = 0;
+        mRightWheelVelocityCommand = 0;
+        mRightWheelPositionState = 0;
+
+        mPrevLeftWheelRaw = 0;
+        mPrevRightWheelRaw = 0;
+        mOdomLeftOverflow = 0;
+        mOdomRightOverflow = 0;
+
+        motion_board_.init();
+        motion_board_.start();
+
+        motion_board_.set_kp_left(kp_left_);
+        motion_board_.set_ki_left(ki_left_);
+        motion_board_.set_kd_left(kd_left_);
+
+        motion_board_.set_kp_right(kp_right_);
+        motion_board_.set_ki_right(ki_right_);
+        motion_board_.set_kd_right(kd_right_);
+
         return hardware_interface::return_type::OK;
     }
 
     hardware_interface::return_type RobotHardwareInterface::stop()
     {
         status_ = hardware_interface::status::STOPPED;
+        motion_board_.halt();
+
         return hardware_interface::return_type::OK;
     }
 
@@ -46,8 +87,24 @@ namespace mep3_driver
     hardware_interface::return_type RobotHardwareInterface::read()
     {
         // Read encoder data from the robot
-        mLeftWheelPositionState = 0;
-        mRightWheelPositionState = 0;
+        int32_t tmp_left, tmp_right;
+        std::tie(tmp_left, tmp_right) = motion_board_.get_encoders();
+
+        const int32_t leftWheelRaw = tmp_left;
+        const int32_t rightWheelRaw = tmp_right;
+
+        // Handle overflow
+        if (llabs((int64_t)mPrevLeftWheelRaw - (int64_t)leftWheelRaw) > POW2(31) - 1)
+            mOdomLeftOverflow = (mPrevLeftWheelRaw > 0 && leftWheelRaw < 0) ? mOdomLeftOverflow + 1 : mOdomLeftOverflow - 1;
+        if (llabs((int64_t)mPrevRightWheelRaw - (int64_t)rightWheelRaw) > POW2(31) - 1)
+            mOdomRightOverflow = (mPrevRightWheelRaw > 0 && rightWheelRaw < 0) ? mOdomRightOverflow + 1 : mOdomRightOverflow - 1;
+        const int64_t leftWheelCorrected = mOdomLeftOverflow * POW2(32) + leftWheelRaw;
+        const int64_t rightWheelCorrected = mOdomRightOverflow * POW2(32) + rightWheelRaw;
+        const double leftWheelRad = leftWheelCorrected / (ENCODER_RESOLUTION / (2 * M_PI));
+        const double rightWheelRad = rightWheelCorrected / (ENCODER_RESOLUTION / (2 * M_PI));
+
+        mLeftWheelPositionState = leftWheelRad;
+        mRightWheelPositionState = rightWheelRad;
 
         return hardware_interface::return_type::OK;
     }
@@ -55,8 +112,24 @@ namespace mep3_driver
     hardware_interface::return_type RobotHardwareInterface::write()
     {
         // Send left and right wheel velocity commands to the robot
-        std::cout << "mLeftWheelVelocityCommand: " << mLeftWheelVelocityCommand << std::endl;
+
+        /*std::cout << "mLeftWheelVelocityCommand: " << mLeftWheelVelocityCommand << std::endl;
+        std::cout << "mRightWheelVelocityCommand: " << mRightWheelVelocityCommand << std::endl;*/
+
+        // convert rad/s to inc/2ms         -> NOTE: 2 ms!! Control loop on motion board runs at 500 Hz = 2 ms period
+        const double speed_double_left = mLeftWheelVelocityCommand * 8.192 / M_PI;
+        const double speed_double_right = mRightWheelVelocityCommand * 8.192 / M_PI;
+
+        const int16_t speed_increments_left = (int16_t) round(speed_double_left);
+        const int16_t speed_increments_right = (int16_t) round(speed_double_right);
+
+        motion_board_.set_setpoints(speed_increments_left, speed_increments_right);
+
+        /*std::cout << "mLeftWheelVelocityCommand: " << mLeftWheelVelocityCommand << std::endl;
         std::cout << "mRightWheelVelocityCommand: " << mRightWheelVelocityCommand << std::endl;
+
+        std::cout << "speed_increments_left: " << speed_increments_left << std::endl;
+        std::cout << "speed_increments_right: " << speed_increments_right << std::endl;*/
 
         return hardware_interface::return_type::OK;
     }


### PR DESCRIPTION
Ros2 to motion board hardware interface implemented.
CAN Bus frames are received in a POSIX pthread instead of C++ std::thread. If we want to switch this thread to realtime, only pthreads can work in real time, not std::thread.
PID parameters for left and right wheel velocity regulators (inside motion board) are in `/mep3_driver/resource/mep3_big_config.urdf` file.

Encoder overflow detection is based on epuck driver by @lukicdarkoo with small changes.
This detection exists just to be safe, but encoder counter registers are 32 bit wide and overflow is practically impossible during a match.