### PR TITLE
Velocity state for wheel joints

### DIFF
--- a/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
+++ b/mep3_driver/include/mep3_driver/robot_hardware_interface.hpp
@@ -28,8 +28,10 @@ namespace mep3_driver
     private:
         double left_wheel_velocity_command_;
         double left_wheel_position_state_;
+        double left_wheel_velocity_state_;
         double right_wheel_velocity_command_;
         double right_wheel_position_state_;
+        double right_wheel_velocity_state_;
 
         int32_t prev_left_wheel_raw_;
         int32_t prev_right_wheel_raw_;
@@ -38,6 +40,7 @@ namespace mep3_driver
 
         float kp_left_, ki_left_, kd_left_;
         float kp_right_, ki_right_, kd_right_;
+        double update_rate_;
 
         static constexpr double ENCODER_RESOLUTION = 8192.0; // 2048 * 4
 

--- a/mep3_driver/launch/driver_launch.py
+++ b/mep3_driver/launch/driver_launch.py
@@ -31,7 +31,18 @@ def generate_launch_description():
         arguments=['diffdrive_controller']
     )
 
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner.py',
+        parameters=[
+            ros2_control_params
+        ],
+        output='screen',
+        arguments=['joint_state_broadcaster']
+    )
+
     return LaunchDescription([
         controller_manager_node,
-        diffdrive_controller_spawner
+        diffdrive_controller_spawner,
+        joint_state_broadcaster_spawner
     ])

--- a/mep3_driver/resource/mep3_big_config.urdf
+++ b/mep3_driver/resource/mep3_big_config.urdf
@@ -10,6 +10,8 @@
             <param name="kp_right">120.0</param>
             <param name="ki_right">1.5</param>
             <param name="kd_right">0.0</param>
+
+            <param name="update_rate">50.0</param>
         </hardware>
         <joint name="left_motor">
             <state_interface name="position" />

--- a/mep3_driver/src/motion_board_driver.cpp
+++ b/mep3_driver/src/motion_board_driver.cpp
@@ -48,7 +48,11 @@ namespace mep3_driver
 
         memset(&ifr_, 0, sizeof(ifr_));
         strcpy(ifr_.ifr_name, "can0");
-        ioctl(canbus_socket_, SIOCGIFINDEX, &ifr_);
+        if (ioctl(canbus_socket_, SIOCGIFINDEX, &ifr_) < 0)
+        {
+            std::cerr << "ioctl fail! Does can interface 'can0' exist?\n";
+            return 1;
+        }
 
         address_.can_family = AF_CAN;
         address_.can_ifindex = ifr_.ifr_ifindex;

--- a/mep3_driver/src/robot_hardware_interface.cpp
+++ b/mep3_driver/src/robot_hardware_interface.cpp
@@ -1,10 +1,12 @@
 #include "mep3_driver/robot_hardware_interface.hpp"
 
 #include <iostream>
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
-
 #include <cmath>
 #include <cstring>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/rclcpp.hpp"
+
 
 namespace mep3_driver
 {
@@ -47,7 +49,12 @@ namespace mep3_driver
         odom_left_overflow_ = 0;
         odom_right_overflow_ = 0;
 
-        motion_board_.init();
+        int board_init_status = motion_board_.init();
+        if (board_init_status != 0)
+        {
+            RCLCPP_FATAL(rclcpp::get_logger("mep3_driver"), "Motion board low lever driver init failed! Is 'can0' up?\n");
+            return hardware_interface::return_type::ERROR;
+        }
         motion_board_.start();
 
         motion_board_.set_kp_left(kp_left_);

--- a/mep3_driver/src/robot_hardware_interface.cpp
+++ b/mep3_driver/src/robot_hardware_interface.cpp
@@ -23,6 +23,8 @@ namespace mep3_driver
         ki_right_ = std::stof(info_.hardware_parameters["ki_right"]);
         kd_right_ = std::stof(info_.hardware_parameters["kd_right"]);
 
+        update_rate_ = std::stod(info_.hardware_parameters["update_rate"]);
+
         std::cout << "KP Left: " << kp_left_ << "\tKI Left: " << ki_left_ << "\tKD Left: " << kd_left_ << std::endl;
         std::cout << "KP Left: " << kp_right_ << "\tKI_Right: " << ki_right_ << "\tKD Right: " << kd_right_ << std::endl;
 
@@ -71,7 +73,9 @@ namespace mep3_driver
     {
         std::vector<hardware_interface::StateInterface> interfaces;
         interfaces.emplace_back(hardware_interface::StateInterface("left_motor", hardware_interface::HW_IF_POSITION, &left_wheel_position_state_));
+        interfaces.emplace_back(hardware_interface::StateInterface("left_motor", hardware_interface::HW_IF_VELOCITY, &left_wheel_velocity_state_));
         interfaces.emplace_back(hardware_interface::StateInterface("right_motor", hardware_interface::HW_IF_POSITION, &right_wheel_position_state_));
+        interfaces.emplace_back(hardware_interface::StateInterface("right_motor", hardware_interface::HW_IF_VELOCITY, &right_wheel_velocity_state_));
         return interfaces;
     }
 
@@ -93,17 +97,31 @@ namespace mep3_driver
         const int32_t right_wheel_raw = tmp_right;
 
         // Handle overflow
+        const int64_t prev_left_wheel_corrected = odom_left_overflow_ * POW2(32) + prev_left_wheel_raw_;
+        const int64_t prev_right_wheel_corrected = odom_right_overflow_ * POW2(32) + prev_right_wheel_raw_;
         if (llabs((int64_t)prev_left_wheel_raw_ - (int64_t)left_wheel_raw) > POW2(31) - 1)
             odom_left_overflow_ = (prev_left_wheel_raw_ > 0 && left_wheel_raw < 0) ? odom_left_overflow_ + 1 : odom_left_overflow_ - 1;
         if (llabs((int64_t)prev_right_wheel_raw_ - (int64_t)right_wheel_raw) > POW2(31) - 1)
             odom_right_overflow_ = (prev_right_wheel_raw_ > 0 && right_wheel_raw < 0) ? odom_right_overflow_ + 1 : odom_right_overflow_ - 1;
-        const int64_t leftWheelCorrected = odom_left_overflow_ * POW2(32) + left_wheel_raw;
-        const int64_t rightWheelCorrected = odom_right_overflow_ * POW2(32) + right_wheel_raw;
-        const double leftWheelRad = leftWheelCorrected / (ENCODER_RESOLUTION / (2 * M_PI));
-        const double rightWheelRad = rightWheelCorrected / (ENCODER_RESOLUTION / (2 * M_PI));
+        const int64_t left_wheel_corrected = odom_left_overflow_ * POW2(32) + left_wheel_raw;
+        const int64_t right_wheel_corrected = odom_right_overflow_ * POW2(32) + right_wheel_raw;
+        const double left_wheel_rad = left_wheel_corrected / (ENCODER_RESOLUTION / (2 * M_PI));
+        const double right_wheel_rad = right_wheel_corrected / (ENCODER_RESOLUTION / (2 * M_PI));
+        const double prev_left_wheel_rad = prev_left_wheel_corrected / (ENCODER_RESOLUTION / (2 * M_PI));
+        const double prev_right_wheel_rad = prev_right_wheel_corrected / (ENCODER_RESOLUTION / (2 * M_PI));
 
-        left_wheel_position_state_ = leftWheelRad;
-        right_wheel_position_state_ = rightWheelRad;
+        // calculate velocities
+        const double left_wheel_velocity_rad = (left_wheel_rad - prev_left_wheel_rad) * update_rate_;       // 1 / sample_period = update_rate
+        const double right_wheel_velocity_rad = (right_wheel_rad - prev_right_wheel_rad) * update_rate_;
+
+        left_wheel_position_state_ = left_wheel_rad;
+        right_wheel_position_state_ = right_wheel_rad;
+
+        left_wheel_velocity_state_ = left_wheel_velocity_rad;
+        right_wheel_velocity_state_ = right_wheel_velocity_rad;
+
+        prev_left_wheel_raw_ = left_wheel_raw;
+        prev_right_wheel_raw_ = right_wheel_raw;
 
         return hardware_interface::return_type::OK;
     }


### PR DESCRIPTION
Added velocity state to robot wheel joints, error reporting if `can0` is not up.