### PR TITLE
Rpp fix rotation

### DIFF
--- a/mep3_navigation/params/nav2_params_big.yaml
+++ b/mep3_navigation/params/nav2_params_big.yaml
@@ -82,9 +82,9 @@ controller_server:
       max_linear_jerk: 5.0
       max_angular_jerk: 500.0
       lookahead_dist: 0.2
-      min_lookahead_dist: 0.05
-      max_lookahead_dist: 0.55
-      lookahead_time: 1.375
+      min_lookahead_dist: 0.15
+      max_lookahead_dist: 0.6
+      lookahead_time: 1.5
       rotate_to_heading_angular_vel: 2.5
       transform_tolerance: 0.1
       use_velocity_scaled_lookahead_dist: true

--- a/mep3_navigation/src/laser_inflator/laser_inflator.cpp
+++ b/mep3_navigation/src/laser_inflator/laser_inflator.cpp
@@ -33,7 +33,8 @@ namespace mep3_driver
 class LaserInflator : public rclcpp::Node
 {
 public:
-  LaserInflator() : Node("laser_inflator")
+  LaserInflator()
+  : Node("laser_inflator")
   {
     this->declare_parameter("inflation_radius", 0.05);
     this->declare_parameter("inflation_angular_step", 0.09);
@@ -70,7 +71,8 @@ private:
     float point_angle = scan.angle_min;  // angle of current point from incoming laser data
     // iterate through received laser points
     for (auto it = scan.ranges.begin(); it != scan.ranges.end();
-         it++, point_angle += scan.angle_increment) {
+      it++, point_angle += scan.angle_increment)
+    {
       if (*it == std::numeric_limits<float>::infinity()) {
         continue;
       }
@@ -123,7 +125,8 @@ private:
 
     float point_angle = scan.angle_min + transform_angle;  // apply rotation
     for (auto it = scan.ranges.begin(); it != scan.ranges.end();
-         it++, point_angle += scan.angle_increment) {
+      it++, point_angle += scan.angle_increment)
+    {
       if (*it == std::numeric_limits<float>::infinity()) {
         continue;
       }
@@ -137,7 +140,8 @@ private:
       const double shrink = 0.1;
       if (
         (x >= -1.5 + shrink) && (x <= 1.5 - shrink) && (y >= -1.0 + shrink) &&
-        (y <= 1.0 - shrink)) {
+        (y <= 1.0 - shrink))
+      {
         // point is valid, don't touch it, continue
         continue;
       } else {

--- a/mep3_navigation/src/regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.cpp
+++ b/mep3_navigation/src/regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.cpp
@@ -319,6 +319,8 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
     angle_profile_output_.new_velocity = {0.0};
     angle_profile_output_.new_acceleration = {0.0};
     angle_profile_output_.pass_to_input(angle_profile_input_);
+
+    rotating_ = false;
   }
   system_time_ = t;
 
@@ -643,6 +645,9 @@ void RegulatedPurePursuitController::applyConstraints(
 void RegulatedPurePursuitController::setPlan(const nav_msgs::msg::Path & path)
 {
   global_plan_ = path;
+
+  angle_profile_input_.control_interface = ruckig::ControlInterface::Velocity;
+  rotating_ = false;
 }
 
 void RegulatedPurePursuitController::setSpeedLimit(


### PR DESCRIPTION
Postojao je bag da se `rotation_` flag ne resetuje kad dodje nova putanja, na ovo je ukazao lik koji je probao kod iz PR za `nav2` paket. Dodatno uvecao sam minimalni lookahead pa bi trebalo biti jos manje oscilacija.