### PR TITLE
Improve navigation performance

### DIFF
--- a/mep3_navigation/params/nav2_params_big.yaml
+++ b/mep3_navigation/params/nav2_params_big.yaml
@@ -189,7 +189,7 @@ local_costmap:
       rolling_window: true
       width: 2
       height: 2
-      resolution: 0.002
+      resolution: 0.05
       robot_radius: 0.15
       plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
       obstacle_layer:
@@ -206,10 +206,6 @@ local_costmap:
       static_layer:
         plugin: "nav2_costmap_2d::StaticLayer"
         map_subscribe_transient_local: True
-      inflation_layer:
-        plugin: "nav2_costmap_2d::InflationLayer"
-        cost_scaling_factor: 4.0
-        inflation_radius: 0.6
       always_send_full_costmap: True
   local_costmap_client:
     ros__parameters:
@@ -227,7 +223,7 @@ global_costmap:
       robot_base_frame: base_link
       use_sim_time: True
       robot_radius: 0.15
-      resolution: 0.002
+      resolution: 0.05
       track_unknown_space: true
       plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
       obstacle_layer:


### PR DESCRIPTION
Rezolucija ne utice na preciznost navigacije. Testirao sam tako sto sam stavio rezoluciju 0.2 i slao robota u dijelove kvadrata. Mislim da je 0.05 sasvim dovoljno.

inflation_layer nam ne treba u lokalnij costmap-i, svejedno RPP to ignorise?