### PR TITLE
Add shared blackboard

### DIFF
--- a/mep3_behavior_tree/CMakeLists.txt
+++ b/mep3_behavior_tree/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(rclcpp_action REQUIRED)
 find_package(mep3_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(can_msgs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 
 # Use static linking for BT Nodes
 add_compile_definitions(MANUAL_STATIC_LINKING)
@@ -56,6 +57,7 @@ ament_target_dependencies(
   mep3_msgs
   nav2_msgs
   can_msgs
+  diagnostic_msgs
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/mep3_behavior_tree/include/mep3_behavior_tree/navigate_through_action.hpp
+++ b/mep3_behavior_tree/include/mep3_behavior_tree/navigate_through_action.hpp
@@ -1,0 +1,92 @@
+// Copyright 2021 Memristor Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEP3_BEHAVIOR_TREE__NAVIGATE_THROUGH_ACTION_HPP_
+#define MEP3_BEHAVIOR_TREE__NAVIGATE_THROUGH_ACTION_HPP_
+
+#include <string>
+#include <cmath>
+
+#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "mep3_behavior_tree/bt_action_node.hpp"
+#include "mep3_behavior_tree/pose_2d.hpp"
+#include "mep3_behavior_tree/team_color_strategy_mirror.hpp"
+#include "nav2_msgs/action/navigate_through_poses.hpp"
+
+namespace mep3_behavior_tree
+{
+  class NavigateThroughAction
+      : public mep3_behavior_tree::BtActionNode<nav2_msgs::action::NavigateThroughPoses>
+  {
+  public:
+    explicit NavigateThroughAction(const std::string &xml_tag_name, const BT::NodeConfiguration &config)
+        : mep3_behavior_tree::BtActionNode<nav2_msgs::action::NavigateThroughPoses>(
+              xml_tag_name, "navigate_through_poses", config)
+    {
+    }
+
+    void on_tick() override;
+    BT::NodeStatus on_success() override;
+
+    static BT::PortsList providedPorts()
+    {
+      return {
+          BT::InputPort<BT::Pose2D>("goal"),
+          BT::InputPort<std::string>("behavior_tree")};
+    }
+  };
+
+  void NavigateThroughAction::on_tick()
+  {
+    std::vector<BT::Pose2D> poses;
+    std::string behavior_tree;
+    getInput("goal", poses);
+    getInput("behavior_tree", behavior_tree);
+
+    goal_.behavior_tree = behavior_tree;
+    for (auto &pose : poses)
+    {
+      g_StrategyMirror.mirror_pose(pose);
+
+      geometry_msgs::msg::PoseStamped pose_stamped;
+      pose_stamped.header.frame_id = "map";
+      pose_stamped.header.stamp = node_->get_clock()->now();
+
+      // Position
+      pose_stamped.pose.position.x = pose.x;
+      pose_stamped.pose.position.y = pose.y;
+
+      // Orientation (yaw)
+      // Convert deg to rad
+      const double theta = pose.theta * M_PI / 180.0;
+      // https://math.stackexchange.com/a/1972382
+      pose_stamped.pose.orientation.w = std::cos(theta / 2.0);
+      pose_stamped.pose.orientation.z = std::sin(theta / 2.0);
+
+      goal_.poses.push_back(pose_stamped);
+    }
+  }
+
+  BT::NodeStatus NavigateThroughAction::on_success()
+  {
+    std::cout << "Navigation succesful " << std::endl;
+
+    return BT::NodeStatus::SUCCESS;
+  }
+
+} // namespace mep3_behavior_tree
+
+#endif // MEP3_BEHAVIOR_TREE__NAVIGATE_THROUGH_ACTION_HPP_

--- a/mep3_behavior_tree/include/mep3_behavior_tree/pose_2d.hpp
+++ b/mep3_behavior_tree/include/mep3_behavior_tree/pose_2d.hpp
@@ -16,6 +16,7 @@
 #define MEP3_BEHAVIOR_TREE__POSE_2D_HPP_
 
 #include <string>
+#include <vector>
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"
@@ -46,6 +47,33 @@ inline Pose2D convertFromString(StringView str)
     return output;
   }
 }
+
+template<>
+inline std::vector<Pose2D> convertFromString(StringView str)
+{
+  // The next line should be removed...
+  printf("Converting string: \"%s\"\n", str.data());
+
+  std::vector<Pose2D> output;
+
+  auto posesParts = splitString(str, '|');
+  for (auto &posePart : posesParts) {
+    // We expect real numbers separated by semicolons
+    auto parts = splitString(posePart, ';');
+    if (parts.size() != 3) {
+      throw RuntimeError("invalid input)");
+    } else {
+      Pose2D pose;
+      pose.x = convertFromString<double>(parts[0]);
+      pose.y = convertFromString<double>(parts[1]);
+      pose.theta = convertFromString<double>(parts[2]);
+      output.push_back(pose);
+    }
+  }
+
+  return output;
+}
+
 }  // namespace BT
 
 #endif  // MEP3_BEHAVIOR_TREE__POSE_2D_HPP_

--- a/mep3_behavior_tree/include/mep3_behavior_tree/set_shared_blackboard_action.hpp
+++ b/mep3_behavior_tree/include/mep3_behavior_tree/set_shared_blackboard_action.hpp
@@ -38,7 +38,7 @@ namespace mep3_behavior_tree
     {
       node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
       blackboard_publisher_ = node_->create_publisher<KeyValueT>(
-          "shared_blackboard", rclcpp::SystemDefaultsQoS().reliable());
+          "/shared_blackboard", rclcpp::SystemDefaultsQoS().reliable());
     }
 
     SetSharedBlackboardAction() = delete;

--- a/mep3_behavior_tree/include/mep3_behavior_tree/set_shared_blackboard_action.hpp
+++ b/mep3_behavior_tree/include/mep3_behavior_tree/set_shared_blackboard_action.hpp
@@ -1,0 +1,78 @@
+// Copyright 2022 Memristor Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEP3_BEHAVIOR_TREE__SET_SHARED_BLACKBOARD_ACTION_HPP_
+#define MEP3_BEHAVIOR_TREE__SET_SHARED_BLACKBOARD_ACTION_HPP_
+
+#include <iostream>
+#include <string>
+
+#include "diagnostic_msgs/msg/key_value.hpp"
+
+#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp_v3/action_node.h"
+#include "rclcpp/rclcpp.hpp"
+
+namespace mep3_behavior_tree
+{
+
+  using KeyValueT = diagnostic_msgs::msg::KeyValue;
+
+  class SetSharedBlackboardAction : public BT::AsyncActionNode
+  {
+  public:
+    SetSharedBlackboardAction(const std::string &name, const BT::NodeConfiguration &config_)
+        : BT::AsyncActionNode(name, config_)
+    {
+      node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+      blackboard_publisher_ = node_->create_publisher<KeyValueT>(
+          "shared_blackboard", rclcpp::SystemDefaultsQoS().reliable());
+    }
+
+    SetSharedBlackboardAction() = delete;
+
+    BT::NodeStatus tick() override;
+
+    static BT::PortsList providedPorts()
+    {
+      return {
+          BT::InputPort<std::string>("output_key"),
+          BT::InputPort<std::string>("value")};
+    }
+
+  private:
+    rclcpp::Node::SharedPtr node_;
+    rclcpp::Publisher<KeyValueT>::SharedPtr blackboard_publisher_;
+  };
+
+  BT::NodeStatus SetSharedBlackboardAction::tick()
+  {
+    std::string output_key;
+    std::string value;
+    getInput("output_key", output_key);
+    getInput("value", value);
+
+    auto msg = KeyValueT();
+    msg.key = output_key;
+    msg.value = value;
+    blackboard_publisher_->publish(msg);
+    config().blackboard->set(output_key, value);
+
+    return BT::NodeStatus::SUCCESS;
+  }
+
+} // namespace mep3_behavior_tree
+
+#endif // MEP3_BEHAVIOR_TREE__SET_SHARED_BLACKBOARD_ACTION_HPP_

--- a/mep3_behavior_tree/include/mep3_behavior_tree/set_shared_blackboard_action.hpp
+++ b/mep3_behavior_tree/include/mep3_behavior_tree/set_shared_blackboard_action.hpp
@@ -38,7 +38,7 @@ namespace mep3_behavior_tree
     {
       node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
       blackboard_publisher_ = node_->create_publisher<KeyValueT>(
-          "/shared_blackboard", rclcpp::SystemDefaultsQoS().reliable());
+          "/shared_blackboard", rclcpp::SystemDefaultsQoS().reliable().transient_local());
     }
 
     SetSharedBlackboardAction() = delete;

--- a/mep3_behavior_tree/include/mep3_behavior_tree/wait_match_start_action.hpp
+++ b/mep3_behavior_tree/include/mep3_behavior_tree/wait_match_start_action.hpp
@@ -39,7 +39,7 @@ public:
     rclcpp::SubscriptionOptions sub_option;
     sub_option.callback_group = callback_group_;
     match_start_sub_ = node_->create_subscription<std_msgs::msg::Int8>(
-      "/match_start_status", rclcpp::SystemDefaultsQoS(),
+      "/match_start_status", rclcpp::SystemDefaultsQoS().reliable(),
       std::bind(&WaitMatchStartAction::matchStartCallback, this, std::placeholders::_1),
       sub_option);
   }

--- a/mep3_behavior_tree/package.xml
+++ b/mep3_behavior_tree/package.xml
@@ -6,6 +6,8 @@
   <description>Memristor Eurobot Platform Strategy Planner</description>
   <maintainer email="info@memristorrobotics.com">memristor</maintainer>
   <license>http://www.apache.org/licenses/LICENSE-2.0</license>
+
+  <depend>diagnostic_msgs</depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rclcpp_action</build_depend>

--- a/mep3_behavior_tree/src/mep3_behavior_tree.cpp
+++ b/mep3_behavior_tree/src/mep3_behavior_tree.cpp
@@ -43,120 +43,120 @@ using KeyValueT = diagnostic_msgs::msg::KeyValue;
 
 int main(int argc, char **argv)
 {
-  // Load strategy from file
-  if (argc < 2)
-  {
-    std::cerr << "Error: Missing argument: strategy name" << std::endl;
-    return 1;
-  }
-  auto tree_file =
-      (std::filesystem::path(ASSETS_DIRECTORY) / "strategies" / argv[1]).replace_extension(".xml");
-  if (!std::filesystem::exists(tree_file))
-  {
-    std::cerr << "Error: Strategy file " << tree_file << " does not exist" << std::endl;
-    return 1;
-  }
+    // Load strategy from file
+    if (argc < 2)
+    {
+        std::cerr << "Error: Missing argument: strategy name" << std::endl;
+        return 1;
+    }
+    auto tree_file =
+        (std::filesystem::path(ASSETS_DIRECTORY) / "strategies" / argv[1]).replace_extension(".xml");
+    if (!std::filesystem::exists(tree_file))
+    {
+        std::cerr << "Error: Strategy file " << tree_file << " does not exist" << std::endl;
+        return 1;
+    }
 
-  rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("mep3_behavior_tree");
-  auto blackboard = BT::Blackboard::create();
-  blackboard->set("node", node);
+    rclcpp::init(argc, argv);
+    auto node = rclcpp::Node::make_shared("mep3_behavior_tree");
+    auto blackboard = BT::Blackboard::create();
+    blackboard->set("node", node);
 
-  node->create_subscription<KeyValueT>(
-      "/shared_blackboard", rclcpp::SystemDefaultsQoS().reliable(), [&blackboard](const KeyValueT::SharedPtr msg)
-      { blackboard->set(msg->key, msg->value); });
+    auto blackboard_subscription = node->create_subscription<KeyValueT>(
+        "/shared_blackboard", rclcpp::SystemDefaultsQoS().reliable().transient_local(), [blackboard](const KeyValueT::SharedPtr msg)
+        { blackboard->set(msg->key, msg->value); });
 
-  std::string name(node->get_namespace());
-  name = name.replace(name.find("/"), sizeof("/") - 1, "");
-  blackboard->set("namespace", name);
+    std::string name(node->get_namespace());
+    name = name.replace(name.find("/"), sizeof("/") - 1, "");
+    blackboard->set("namespace", name);
 
-  node->declare_parameter<std::string>("table", "");
-  auto table = node->get_parameter("table");
-  blackboard->set("table", table.as_string());
+    node->declare_parameter<std::string>("table", "");
+    auto table = node->get_parameter("table");
+    blackboard->set("table", table.as_string());
 
-  blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_duration",
-      std::chrono::milliseconds(10));
-  blackboard->set<std::chrono::milliseconds>(
-      "server_timeout",
-      std::chrono::milliseconds(1000));
+    blackboard->set<std::chrono::milliseconds>(
+        "bt_loop_duration",
+        std::chrono::milliseconds(10));
+    blackboard->set<std::chrono::milliseconds>(
+        "server_timeout",
+        std::chrono::milliseconds(1000));
 
-  node->declare_parameter<std::string>("color", "purple");
-  auto color = node->get_parameter("color");
-  mep3_behavior_tree::g_StrategyMirror.set_color(color.as_string());
+    node->declare_parameter<std::string>("color", "purple");
+    auto color = node->get_parameter("color");
+    mep3_behavior_tree::g_StrategyMirror.set_color(color.as_string());
 
-  BT::BehaviorTreeFactory factory;
+    BT::BehaviorTreeFactory factory;
 
-  BT::SharedLibrary loader;
-  factory.registerFromPlugin(loader.getOSName("nav2_clear_costmap_service_bt_node"));
-  factory.registerFromPlugin(loader.getOSName("nav2_recovery_node_bt_node"));
+    BT::SharedLibrary loader;
+    factory.registerFromPlugin(loader.getOSName("nav2_clear_costmap_service_bt_node"));
+    factory.registerFromPlugin(loader.getOSName("nav2_recovery_node_bt_node"));
 
-  factory.registerNodeType<mep3_behavior_tree::CanbusSendAction>(
-      "CanbusSend");
-  factory.registerNodeType<mep3_behavior_tree::SetSharedBlackboardAction>(
-      "SetSharedBlackboard");
-  factory.registerNodeType<mep3_behavior_tree::DelayAction>(
-      "Wait");
-  factory.registerNodeType<mep3_behavior_tree::DynamixelCommandAction>(
-      "Dynamixel");
-  factory.registerNodeType<mep3_behavior_tree::MotionCommandAction>(
-      "Motion");
-  factory.registerNodeType<mep3_behavior_tree::NavigateToAction>(
-      "Navigate");
-  factory.registerNodeType<mep3_behavior_tree::PreciseNavigateToAction>(
-      "PreciseNavigate");
-  factory.registerNodeType<mep3_behavior_tree::VacuumPumpCommandAction>(
-      "VacuumPump");
-  factory.registerNodeType<mep3_behavior_tree::ResistanceMeterAction>(
-      "ResistanceMeter");
-  factory.registerNodeType<mep3_behavior_tree::ScoreboardTaskAction>(
-      "ScoreboardTask");
-  factory.registerNodeType<mep3_behavior_tree::WaitMatchStartAction>(
-      "WaitMatchStart");
-  factory.registerNodeType<mep3_behavior_tree::LiftCommandAction>(
-      "Lift");
-  factory.registerNodeType<mep3_behavior_tree::IfTeamColorThenElseControl>(
-      "IfTeamColorThenElse");
-  factory.registerNodeType<mep3_behavior_tree::TaskSequenceControl>(
-      "TaskSequence");
-  factory.registerNodeType<mep3_behavior_tree::NavigateThroughAction>(
-      "NavigateThrough");
+    factory.registerNodeType<mep3_behavior_tree::CanbusSendAction>(
+        "CanbusSend");
+    factory.registerNodeType<mep3_behavior_tree::SetSharedBlackboardAction>(
+        "SetSharedBlackboard");
+    factory.registerNodeType<mep3_behavior_tree::DelayAction>(
+        "Wait");
+    factory.registerNodeType<mep3_behavior_tree::DynamixelCommandAction>(
+        "Dynamixel");
+    factory.registerNodeType<mep3_behavior_tree::MotionCommandAction>(
+        "Motion");
+    factory.registerNodeType<mep3_behavior_tree::NavigateToAction>(
+        "Navigate");
+    factory.registerNodeType<mep3_behavior_tree::PreciseNavigateToAction>(
+        "PreciseNavigate");
+    factory.registerNodeType<mep3_behavior_tree::VacuumPumpCommandAction>(
+        "VacuumPump");
+    factory.registerNodeType<mep3_behavior_tree::ResistanceMeterAction>(
+        "ResistanceMeter");
+    factory.registerNodeType<mep3_behavior_tree::ScoreboardTaskAction>(
+        "ScoreboardTask");
+    factory.registerNodeType<mep3_behavior_tree::WaitMatchStartAction>(
+        "WaitMatchStart");
+    factory.registerNodeType<mep3_behavior_tree::LiftCommandAction>(
+        "Lift");
+    factory.registerNodeType<mep3_behavior_tree::IfTeamColorThenElseControl>(
+        "IfTeamColorThenElse");
+    factory.registerNodeType<mep3_behavior_tree::TaskSequenceControl>(
+        "TaskSequence");
+    factory.registerNodeType<mep3_behavior_tree::NavigateThroughAction>(
+        "NavigateThrough");
 
-  // To be deleted
-  factory.registerNodeType<mep3_behavior_tree::MotionCommandAction>(
-      "MotionCommandAction");
-  factory.registerNodeType<mep3_behavior_tree::NavigateToAction>(
-      "NavigateToAction");
-  factory.registerNodeType<mep3_behavior_tree::PreciseNavigateToAction>(
-      "PreciseNavigateToAction");
-  factory.registerNodeType<mep3_behavior_tree::VacuumPumpCommandAction>(
-      "VacuumPumpCommandAction");
-  factory.registerNodeType<mep3_behavior_tree::DynamixelCommandAction>(
-      "DynamixelCommandAction");
-  factory.registerNodeType<mep3_behavior_tree::ResistanceMeterAction>(
-      "ResistanceMeterAction");
-  factory.registerNodeType<mep3_behavior_tree::ScoreboardTaskAction>(
-      "ScoreboardTaskAction");
-  factory.registerNodeType<mep3_behavior_tree::WaitMatchStartAction>(
-      "WaitMatchStartAction");
-  factory.registerNodeType<mep3_behavior_tree::LiftCommandAction>(
-      "LiftCommandAction");
-  factory.registerNodeType<mep3_behavior_tree::DefaultTeamColorCondition>(
-      "DefaultTeamColorCondition");
-  factory.registerNodeType<mep3_behavior_tree::IfTeamColorThenElseControl>(
-      "IfTeamColorThenElseControl");
-  factory.registerNodeType<mep3_behavior_tree::TaskSequenceControl>(
-      "TaskSequenceControl");
+    // To be deleted
+    factory.registerNodeType<mep3_behavior_tree::MotionCommandAction>(
+        "MotionCommandAction");
+    factory.registerNodeType<mep3_behavior_tree::NavigateToAction>(
+        "NavigateToAction");
+    factory.registerNodeType<mep3_behavior_tree::PreciseNavigateToAction>(
+        "PreciseNavigateToAction");
+    factory.registerNodeType<mep3_behavior_tree::VacuumPumpCommandAction>(
+        "VacuumPumpCommandAction");
+    factory.registerNodeType<mep3_behavior_tree::DynamixelCommandAction>(
+        "DynamixelCommandAction");
+    factory.registerNodeType<mep3_behavior_tree::ResistanceMeterAction>(
+        "ResistanceMeterAction");
+    factory.registerNodeType<mep3_behavior_tree::ScoreboardTaskAction>(
+        "ScoreboardTaskAction");
+    factory.registerNodeType<mep3_behavior_tree::WaitMatchStartAction>(
+        "WaitMatchStartAction");
+    factory.registerNodeType<mep3_behavior_tree::LiftCommandAction>(
+        "LiftCommandAction");
+    factory.registerNodeType<mep3_behavior_tree::DefaultTeamColorCondition>(
+        "DefaultTeamColorCondition");
+    factory.registerNodeType<mep3_behavior_tree::IfTeamColorThenElseControl>(
+        "IfTeamColorThenElseControl");
+    factory.registerNodeType<mep3_behavior_tree::TaskSequenceControl>(
+        "TaskSequenceControl");
 
-  BT::Tree tree = factory.createTreeFromFile(tree_file, blackboard);
-  BT::StdCoutLogger logger_cout(tree);
+    BT::Tree tree = factory.createTreeFromFile(tree_file, blackboard);
+    BT::StdCoutLogger logger_cout(tree);
 
-  bool finish = false;
-  while (!finish && rclcpp::ok())
-  {
-    finish = tree.rootNode()->executeTick() == BT::NodeStatus::SUCCESS;
-    rclcpp::spin_some(node);
-  }
-  rclcpp::shutdown();
-  return 0;
+    bool finish = false;
+    while (!finish && rclcpp::ok())
+    {
+        finish = tree.rootNode()->executeTick() == BT::NodeStatus::SUCCESS;
+        rclcpp::spin_some(node);
+    }
+    rclcpp::shutdown();
+    return 0;
 }

--- a/mep3_behavior_tree/src/mep3_behavior_tree.cpp
+++ b/mep3_behavior_tree/src/mep3_behavior_tree.cpp
@@ -36,6 +36,7 @@
 #include "mep3_behavior_tree/delay_action.hpp"
 #include "mep3_behavior_tree/canbus_send_action.hpp"
 #include "mep3_behavior_tree/set_shared_blackboard_action.hpp"
+#include "mep3_behavior_tree/navigate_through_action.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using KeyValueT = diagnostic_msgs::msg::KeyValue;
@@ -118,6 +119,8 @@ int main(int argc, char **argv)
       "IfTeamColorThenElse");
   factory.registerNodeType<mep3_behavior_tree::TaskSequenceControl>(
       "TaskSequence");
+  factory.registerNodeType<mep3_behavior_tree::NavigateThroughAction>(
+      "NavigateThrough");
 
   // To be deleted
   factory.registerNodeType<mep3_behavior_tree::MotionCommandAction>(

--- a/mep3_behavior_tree/src/mep3_behavior_tree.cpp
+++ b/mep3_behavior_tree/src/mep3_behavior_tree.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
   blackboard->set("node", node);
 
   node->create_subscription<KeyValueT>(
-      "shared_blackboard", rclcpp::SystemDefaultsQoS().reliable(), [&blackboard](const KeyValueT::SharedPtr msg)
+      "/shared_blackboard", rclcpp::SystemDefaultsQoS().reliable(), [&blackboard](const KeyValueT::SharedPtr msg)
       { blackboard->set(msg->key, msg->value); });
 
   std::string name(node->get_namespace());

--- a/mep3_bringup/resource/domain_bridge.yaml
+++ b/mep3_bringup/resource/domain_bridge.yaml
@@ -10,3 +10,7 @@ topics:
     to_domain: 2
     type: std_msgs/msg/Int8
     bidirectional: True
+  shared_blackboard:
+    from_domain: 3
+    to_domain: 2
+    type: diagnostic_msgs/msg/KeyValue


### PR DESCRIPTION
This allows setting blackboard key-value pairs on both robots, e.g.:
```xml
<!-- Robot #1 -->
<SetSharedBlackboard output_key="task_1_completed" value="true"/>

<!-- Robot #2 -->
<BlackboardCheckString value_A="{task_1_completed}" value_B="true" return_on_mismatch="SUCCESS">
   <!-- Task 1 is completed and you can skip it -->
</BlackboardCheckString>
```

The blackboard items are accessible through the standard Blackboard API:
https://www.behaviortree.dev/xml_format/#ports-remapping-and-pointers-to-blackboards-entries


---

```xml
<NavigateThrough goal="0.5;0.5;0|0.5;0;0|0;0;0" />
```